### PR TITLE
Rename run_figures to run_notebooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ twine upload dist/*
 
 The library has three modules, each corresponding to a domain:
 
-- **`airoh/utils.py`** — Python env setup, git submodules, editable installs, directory management, and Jupyter notebook execution (`run_figures`)
+- **`airoh/utils.py`** — Python env setup, git submodules, editable installs, directory management, and Jupyter notebook execution (`run_notebooks`)
 - **`airoh/containers.py`** — Docker and Apptainer lifecycle: build, archive to `.tar.gz`/`.sif`, download a prebuilt image, and run an `invoke` task inside a container
 - **`airoh/datalad.py`** — Data retrieval via Datalad: install/get subdatasets, download single tracked files, and download+extract remote archives
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ You can use `airoh` in your project simply by importing tasks in your `tasks.py`
 
 ```python
 # tasks.py
-from airoh.utils import run_figures, setup_env_python
+from airoh.utils import run_notebooks, setup_env_python
 ```
 
 Now you can call:
 
 ```bash
-invoke run-figures
+invoke run-notebooks
 invoke setup-env-python
 ```
 ## Requirements
@@ -39,7 +39,7 @@ invoke setup-env-python
 * [`invoke`](https://www.pyinvoke.org/) ≥ 2.0
 * Docker (for container tasks)
 * Apptainer (optional, for `.sif` support)
-* `jupyter` (if using `run-figures`)
+* `jupyter` (if using `run-notebooks`)
 
 Note that a few more requirements are required for development, in particular [pdoc](https://pdoc.dev/docs/pdoc.html) which is used to generate the documentation website.
 

--- a/airoh/utils.py
+++ b/airoh/utils.py
@@ -208,10 +208,10 @@ def _build_env_from_config(c, keys):
     return env
 
 @task
-def run_figures(c, notebooks_path=None, figures_base=None, keys=None):
-    """📊 Execute all Jupyter notebooks generating figures.
+def run_notebooks(c, notebooks_path=None, figures_base=None, keys=None):
+    """📓 Execute all Jupyter notebooks in a directory.
 
-    Scans the figure notebook directory and executes each notebook that
+    Scans the notebooks directory and executes each notebook that
     doesn't yet have a corresponding output folder. Environment variables
     can be injected based on invoke.yaml configuration.
 
@@ -222,14 +222,14 @@ def run_figures(c, notebooks_path=None, figures_base=None, keys=None):
     notebooks_path : str, optional
         Path to the folder containing notebooks. Defaults to `notebooks_dir`.
     figures_base : str, optional
-        Base directory for figure outputs. Defaults to `figures_dir`.
+        Base directory for notebook outputs. Defaults to `figures_dir`.
     keys : list[str], optional
         List of configuration keys to expose as environment variables.
 
     Examples
     --------
     ```bash
-    inv utils.run-figures
+    inv utils.run-notebooks
     ```
     """
     notebooks_path = Path(notebooks_path or c.config.get("notebooks_dir", "code/figures"))


### PR DESCRIPTION
## Summary

- Renames `run_figures` → `run_notebooks` in `airoh/utils.py`, `README.md`, and `CLAUDE.md`
- Updates docstring to reflect that notebooks don't necessarily produce figures
- Docs regenerated locally (CI will rebuild on merge)

Closes #14

## Test plan

- [x] `pytest -m "not integration"` passes
- [x] `invoke make-docs` produces HTML with `run_notebooks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)