### PR TITLE
Add download_data task, datalad optional dep, and bump to v0.2.0

### DIFF
--- a/airoh/datalad.py
+++ b/airoh/datalad.py
@@ -1,8 +1,15 @@
 # src/airoh/datalad.py
+import shutil
+
+if not shutil.which("datalad"):
+    raise ImportError(
+        "The 'datalad' CLI is required for airoh.datalad tasks. "
+        "Install it with: pip install airoh[datalad]"
+    )
+
 from invoke import task
 import os
 import shlex
-import shutil
 from pathlib import Path
 
 @task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ license = {text = "MIT"}
 requires-python = ">=3.8"
 dependencies = ["invoke>=2.0"]
 
+[project.optional-dependencies]
+datalad = ["datalad>=0.18"]
+full = ["datalad>=0.18"]
+
 [project.urls]
 Homepage = "https://github.com/simexp/airoh"
 Issues = "https://github.com/SIMEXP/airoh/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "airoh"
-version = "0.1.4"
+version = "0.2.0"
 description = "A lightweight task library for reproducible workflows"
 authors = [{ name = "Lune Bellec", email = "lune.bellec@umontreal.ca" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Adds `download_data` task to `airoh/utils.py` with unit tests
- Adds a guard in `airoh/datalad.py` that raises a clear `ImportError` if the `datalad` CLI is not installed
- Adds `[datalad]` and `[full]` optional dependency extras to `pyproject.toml` (`pip install airoh[datalad]`)
- Bumps version `0.1.4` → `0.2.0`

## Test plan

- [x] All unit tests pass (`pytest -m "not integration"`)
- [ ] Verify `pip install airoh[datalad]` installs datalad correctly
- [ ] Smoke-test `download_data` task in a consumer project

🤖 Generated with [Claude Code](https://claude.com/claude-code)