### PR TITLE
Add verify, provenance, and rewritten datalad modules (0.4.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,13 +45,16 @@ twine upload dist/*
 
 `airoh` is a library of reusable [`invoke`](https://www.pyinvoke.org/) task definitions for reproducible research pipelines. Users import tasks from `airoh` into their project's `tasks.py` and call them via `invoke <module>.<task-name>`.
 
-The library has three modules, each corresponding to a domain:
+The library has six modules, each corresponding to a domain:
 
 - **`airoh/utils.py`** — Python env setup, git submodules, editable installs, directory management, and Jupyter notebook execution (`run_notebooks`)
 - **`airoh/containers.py`** — Docker and Apptainer lifecycle: build, archive to `.tar.gz`/`.sif`, download a prebuilt image, and run an `invoke` task inside a container
-- **`airoh/datalad.py`** — Data retrieval via Datalad: install/get subdatasets, download single tracked files, and download+extract remote archives
+- **`airoh/acquisition.py`** — dependency-light data acquisition: download a single file (`download_data`), symlink/copy already-present data or fall back to downloading (`fetch_data`), and git submodule init/update (`ensure_submodule`)
+- **`airoh/datalad.py`** — Datalad-backed data retrieval, gated behind the optional `datalad` extra: make a dataset checkout available (`ensure_dataset`/`install_dataset`), retrieve content tolerant of partial failures (`datalad_get`/`get_data`), install/update nested subdatasets (`install_subdataset`/`update_subdataset`/`update_dataset`), a failure cache so repeat fetches skip known-inaccessible files (`load_known_failures`/`save_known_failures`), a generic glob-and-fetch helper for projects to compose their own prefetch step (`prefetch_pattern`), and single tracked-file download (`import_file`). Import always succeeds without the `datalad` CLI on PATH — only calling a task raises.
+- **`airoh/provenance.py`** — records what fetch and run actually did: `record_sources` writes `source_data/MANIFEST.json`, `record_run` writes `output_data/PROVENANCE.json`, both checksummed and git/datalad-aware
+- **`airoh/verify.py`** — `invoke verify`: a flat list of independent checks that code, config, data and docs still agree (task list vs. docs, dependency files vs. each other, doc paths, `CONTENT.md` coverage, config keys, tracked file sizes, provenance freshness, lint)
 
-**Configuration contract**: every task reads project-specific values from the consumer project's `invoke.yaml` via `c.config.get(key)`. Key names used across modules: `docker_image`, `docker_archive`, `datasets` (dict), `files` (dict with `url`/`output_file`), `notebooks_dir`, `figures_dir`. Tasks raise `ValueError` if a required key is missing.
+**Configuration contract**: every task reads project-specific values from the consumer project's `invoke.yaml` via `c.config.get(key)`. Key names used across modules: `docker_image`, `docker_archive`, `datasets` (dict, either `{name: path}` or `{name: {output_dir, url, source}}`), `files` (dict with `url`/`output_file`), `notebooks_dir`, `figures_dir`, `output_data_dir`, `source_data_dir`, `verify`, `manifest_file`, `provenance_file`, `provenance_hash_max_bytes`. Tasks raise `ValueError` if a required key is missing. `airoh/verify.py`'s `AIROH_CONFIG_KEYS` must list every key read this way, or `check_config_keys` reports it as an unused project key.
 
 **Container run tasks** (`docker_run`, `apptainer_run`) mount the current working directory into the container at `/home/jovyan/work` and execute an `invoke` task inside it — enabling fully containerized pipeline steps while keeping task definitions in the host `tasks.py`.
 
@@ -59,4 +62,4 @@ The library has three modules, each corresponding to a domain:
 
 **The `tasks.py`** at the repo root defines only `make-docs` — it is the library's own build task, not an example for users.
 
-**Testing** uses a single integration smoke test (`tests/test_airoh_template_smoke.py`) that clones the `airoh-template` repo (URL from `invoke.yaml`), installs the local `airoh` editable, and runs `invoke setup`, `invoke fetch`, `invoke run` end-to-end.
+**Testing** uses a single integration smoke test (`tests/test_airoh_template_smoke.py`) that clones the `airoh-template` repo (URL from `invoke.yaml`), installs the local `airoh` editable, and runs `invoke fetch`, `invoke run`, `invoke verify` end-to-end (there is no `invoke setup` task).

--- a/README.md
+++ b/README.md
@@ -33,6 +33,35 @@ Now you can call:
 invoke run-notebooks
 invoke setup-env-python
 ```
+
+### Keeping a project honest
+
+Two modules exist for the parts of reproducibility that no pipeline run can
+check by itself.
+
+`airoh.verify` compares a project against its own documentation — the task list
+in the README, the packages in `requirements.txt` versus `pyproject.toml`, the
+paths the docs name, the entries in each data folder versus its `CONTENT.md`,
+the size and type of what git tracks. It runs a flat list of independent checks
+and exits non-zero when any fails. Wire it up as its own task and run it before
+committing; never call it from `run`, so that reproducing results never depends
+on documentation hygiene.
+
+`airoh.provenance` writes two records: `record_sources` describes what every
+declared asset actually resolved to (a URL, a real path behind a symlink, the
+commit of the repository it belongs to), and `record_run` describes what
+produced the current outputs (project commit, environment, input manifest,
+output checksums). Neither can fail a pipeline — a provenance record is
+documentation, not a precondition. Where datalad is in use it remains the only
+thing that can *retrieve* a past state; these records are what you get without
+it.
+
+```python
+# tasks.py
+from airoh.verify import verify            # noqa: F401  (exposes `invoke verify`)
+from airoh.provenance import record_run, record_sources
+```
+
 ## Requirements
 
 * Python ≥ 3.8

--- a/airoh/containers.py
+++ b/airoh/containers.py
@@ -1,10 +1,12 @@
 # src/airoh/containers.py
+import gzip
 import os
 import shutil
 import tempfile
-import gzip
 from pathlib import Path
+
 from invoke import task
+
 
 def _set_image(c, image=None):
     """🧩 Resolve the Docker image name.
@@ -31,7 +33,10 @@ def _set_image(c, image=None):
     """
     image = image or c.config.get("docker_image")
     if not image:
-        raise ValueError("No Docker image specified. Please set docker_image in invoke.yaml or pass it explicitly.")
+        raise ValueError(
+            "No Docker image specified. Please set docker_image in invoke.yaml "
+            "or pass it explicitly."
+        )
     return image
 
 @task
@@ -113,7 +118,9 @@ def docker_setup(c, url=None, image=None):
     if not url:
         url = c.config.get("docker_archive")
         if not url:
-            raise ValueError("No archive URL provided. Set docker_archive in invoke.yaml or pass --url.")
+            raise ValueError(
+                "No archive URL provided. Set docker_archive in invoke.yaml or pass --url."
+            )
 
     output = f"{image}.tar.gz"
     if not os.path.exists(output):

--- a/airoh/datalad.py
+++ b/airoh/datalad.py
@@ -1,65 +1,385 @@
 # src/airoh/datalad.py
+"""Datalad-backed data retrieval: install/get subdatasets, tolerant of partial failures.
+
+A datalad dataset is often only partly accessible — some content lives on
+credentialed special remotes a given environment cannot reach. These tasks
+retrieve whatever is reachable and warn (rather than abort) on the rest by
+default, since a single inaccessible file must not fail a whole fetch. Pass
+``strict=True`` (or ``--strict`` on the CLI) where that tolerance is wrong —
+typically only in a smoke test, which must fail loudly when retrieval doesn't
+work at all.
+
+Requires the `datalad` CLI. Import succeeds even when it's absent — only
+calling a task raises, so `invoke --list` and non-datalad projects are never
+affected. Install with `pip install airoh[datalad]`.
+"""
+
+import json
+import os
+import shlex
 import shutil
+import subprocess
+from pathlib import Path
 
-if not shutil.which("datalad"):
-    raise ImportError(
-        "The 'datalad' CLI is required for airoh.datalad tasks. "
-        "Install it with: pip install airoh[datalad]"
-    )
+from invoke import task
 
-# The rest of the imports stay below the guard so a missing datalad CLI raises
-# the message above rather than failing on some unrelated import first. isort
-# leaves them here — it never reorders across an intervening statement.
-import os  # noqa: E402
-import shlex  # noqa: E402
-from pathlib import Path  # noqa: E402
+# Some environments can reach github over HTTPS but not SSH, while a dataset's
+# recorded submodule URLs are often SSH (git@github.com:...). When a first
+# attempt fails we retry once, rewriting SSH github URLs to HTTPS for that
+# single invocation only (no persistent change to the user's git config).
+_HTTPS_OVERRIDE = "url.https://github.com/.insteadOf=git@github.com:"
 
-from invoke import task  # noqa: E402
+# Some datalad content lives on credentialed SSH special remotes a given
+# environment has no key for. Left to their defaults, git/ssh fall back to an
+# interactive password prompt — which reads from stdin and, with no TTY
+# attached to a non-interactive subprocess, blocks forever instead of failing.
+# Forcing batch mode (no prompts) plus a bounded connect timeout makes an
+# unreachable/unauthorized remote fail fast like any other inaccessible
+# content, instead of hanging the whole fetch indefinitely.
+_NONINTERACTIVE_ENV = {
+    **os.environ,
+    "GIT_TERMINAL_PROMPT": "0",
+    "GIT_SSH_COMMAND": (
+        os.environ.get("GIT_SSH_COMMAND", "ssh")
+        + " -o BatchMode=yes -o ConnectTimeout=15"
+    ),
+}
+
+# Hard backstop in case some other step (not git/ssh auth) still stalls —
+# generous enough for a real bulk retrieval, short enough to not hang forever.
+_SUBPROCESS_TIMEOUT_SECONDS = 600
+
+_FAILURES_FILENAME = ".fetch_failures.json"
 
 
-@task
-def get_data(c, name):
-    """
-    📦 Install and retrieve a Datalad subdataset defined in the Invoke configuration.
+def _require_datalad():
+    if not shutil.which("datalad"):
+        raise RuntimeError(
+            "The 'datalad' CLI is required for airoh.datalad tasks. "
+            "Install it with: pip install airoh[datalad]"
+        )
 
-    This task ensures that a given Datalad dataset specified under the
-    `datasets` section of `invoke.yaml` is installed and that all of its
-    contents are retrieved. It is typically used to make sure local data
-    mirrors are up to date or to initialize subdatasets after cloning
-    a parent dataset.
 
-    Parameters
-    ----------
-    c : invoke.Context
-        The Invoke context, automatically provided when called as a task.
-    name : str
-        The name of the dataset as defined under `datasets` in `invoke.yaml`.
+def _dataset_entry(c, name):
+    """Normalize a `datasets:` entry to a dict with `output_dir`, `url`, `source`.
 
-    Raises
-    ------
-    ValueError
-        If the specified dataset name does not exist in the configuration.
-
-    Examples
-    --------
-    ```bash
-    inv datalad.get-data --name image10k
-    ```
+    Accepts either a plain path string (back-compat: `{name: path}`) or a
+    mapping with `output_dir`/`output_file`, `url`, and/or `source` — the
+    same shape `airoh.provenance` reads (see `_asset_entries`).
     """
     datasets = c.config.get("datasets", {})
     if name not in datasets:
         raise ValueError(f"❌ Dataset '{name}' not found in invoke.yaml under 'datasets'.")
 
-    path = datasets[name]
-    print(f"📦 Checking dataset '{name}' at: {path}")
+    entry = datasets[name]
+    if isinstance(entry, str):
+        return {"output_dir": entry, "url": None, "source": None}
+    output_dir = entry.get("output_dir") or entry.get("output_file")
+    if not output_dir:
+        raise ValueError(f"❌ Entry for '{name}' must define 'output_dir'.")
+    return {
+        "output_dir": output_dir,
+        "url": entry.get("url"),
+        "source": entry.get("source"),
+    }
 
-    if not os.path.exists(path):
-        print(f"📥 Installing subdataset '{name}'...")
-        c.run(f"datalad install --recursive {path}")
 
-    print(f"📥 Retrieving data for '{name}'...")
-    c.run(f"datalad get {path}")
-    print("✅ Done.")
+def _is_datalad_dataset(root):
+    root = Path(root)
+    return (root / ".datalad").is_dir() or (root / ".git").exists()
+
+
+def _run(extra_config, args, cwd):
+    cmd = ["datalad"]
+    if extra_config:
+        cmd += ["-c", extra_config]
+    cmd += args
+    try:
+        return subprocess.run(
+            cmd, cwd=str(cwd), capture_output=True, text=True,
+            stdin=subprocess.DEVNULL, env=_NONINTERACTIVE_ENV,
+            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return subprocess.CompletedProcess(
+            cmd, returncode=1, stdout=exc.stdout or "",
+            stderr=(exc.stderr or "") + f"\ntimed out after {_SUBPROCESS_TIMEOUT_SECONDS}s",
+        )
+
+
+def datalad_get(paths, dataset_root, recursive=False, get_content=True, strict=False):
+    """Run `datalad get` for `paths` (relative to `dataset_root`).
+
+    With `get_content=False` only the subdataset tree (filenames) is
+    installed, not the annexed content. On failure it retries once over HTTPS.
+    If that also fails: by default (tolerant) it prints a warning and returns
+    so the caller can proceed with whatever content is present; with
+    `strict=True` it raises `RuntimeError` instead.
+    """
+    _require_datalad()
+    root = Path(dataset_root)
+    if not _is_datalad_dataset(root):
+        if strict:
+            raise RuntimeError(f"{root} is not a Datalad dataset")
+        return
+    if isinstance(paths, (str, Path)):
+        paths = [paths]
+    args = ["get"]
+    if not get_content:
+        args.append("-n")
+    if recursive:
+        args.append("-r")
+    args += [str(p) for p in paths]
+
+    result = _run(None, args, root)
+    if result.returncode != 0:
+        result = _run(_HTTPS_OVERRIDE, args, root)
+    if result.returncode != 0:
+        preview = ", ".join(str(p) for p in paths[:2])
+        if strict:
+            raise RuntimeError(
+                f"datalad get failed for {preview} ...\n{result.stderr.strip()}"
+            )
+        print(f"⚠️  datalad get returned errors (continuing without): {preview} ...")
+
+
+def update_subdataset(path, dataset_root, strict=False):
+    """Advance an already-installed subdataset's pin via `datalad update --merge`.
+
+    Only the git tree (commit pin, filenames) is refreshed — no annexed
+    content is fetched, so this stays cheap even against a large derivative.
+    Non-recursive: it advances only `path` itself, not any subdataset nested
+    inside it. If `path` isn't installed yet (no `.git`), this is a no-op —
+    `install_subdataset` handles that case instead.
+
+    On failure it retries once over HTTPS. By default tolerant (prints a
+    warning and returns) so a stale/unreachable remote never aborts the whole
+    fetch; with `strict=True` it raises `RuntimeError`.
+    """
+    _require_datalad()
+    root = Path(dataset_root) / path
+    if not (root / ".git").exists():
+        return
+    result = _run(None, ["update", "--merge"], root)
+    if result.returncode != 0:
+        result = _run(_HTTPS_OVERRIDE, ["update", "--merge"], root)
+    if result.returncode != 0:
+        if strict:
+            raise RuntimeError(
+                f"datalad update --merge failed for {path}\n{result.stderr.strip()}"
+            )
+        print(f"⚠️  datalad update --merge returned errors (continuing without): {path}")
+
+
+def install_subdataset(path, dataset_root, strict=False):
+    """Install the subdataset at `path` (relative to `dataset_root`), no content.
+
+    Runs `datalad get -n` rather than plain `git submodule update --init`:
+    a nested subdataset (a subdataset inside another subdataset) cannot be
+    reached by plain git submodule commands, which only see the top level.
+    `datalad get -n` installs the intermediate dataset and the nested one in
+    a single call, leaving large sibling subdatasets untouched
+    (non-recursive). By default tolerant like `datalad_get` (only warns), so
+    an inaccessible subdataset never aborts the whole run. With
+    `strict=True` it raises if the subdataset is not actually installed
+    afterwards (no `.git` at `path`).
+
+    When the subdataset is already installed (`.git` already present at
+    `path`), skips the `datalad get -n` install call (the expensive full
+    install is only needed once) but still runs a lightweight
+    `update_subdataset` refresh, so new upstream commits surface on every
+    repeat fetch instead of only at first install.
+    """
+    _require_datalad()
+    if (Path(dataset_root) / path / ".git").exists():
+        update_subdataset(path, dataset_root, strict=strict)
+        return
+    datalad_get(path, dataset_root, get_content=False, strict=strict)
+    if strict and not (Path(dataset_root) / path / ".git").exists():
+        raise RuntimeError(
+            f"subdataset {path} was not installed (no .git at "
+            f"{Path(dataset_root) / path})"
+        )
+
+
+def ensure_dataset(dest, url=None, source=None):
+    """Make a datalad dataset checkout available at `dest`: symlink, clone, or no-op.
+
+    Mirrors `airoh.acquisition.fetch_data`'s "symlink existing data, else
+    acquire it" decision, adapted for a datalad dataset:
+
+    - if `dest` already exists (a prior symlink or clone), this is a no-op;
+    - else if `source` is given, symlink `dest` to the existing checkout at
+      `source` (does not run `datalad get` — un-fetched content in that
+      checkout stays un-fetched; see the template's CLAUDE.md for why
+      symlinking a datalad dataset only exposes what's already present);
+    - else if `url` is given, `datalad clone url dest` (dataset tree only, no
+      annexed content — a later `get_data`/`install_subdataset` call
+      retrieves what's actually needed).
+
+    Raises `ValueError` if neither `source` nor `url` is given and `dest`
+    does not already exist.
+    """
+    dest_path = Path(dest)
+    if dest_path.exists():
+        print(f"🫧 Skipping: {dest} already exists.")
+        return
+
+    if source:
+        source_path = Path(source).expanduser().resolve()
+        if not source_path.exists():
+            raise ValueError(f"❌ Source does not exist: {source_path}")
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.symlink_to(source_path)
+        print(f"✅ Linked {dest} -> {source_path}.")
+        return
+
+    if url:
+        _require_datalad()
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["datalad", "clone", url, str(dest_path)], check=True,
+                       env=_NONINTERACTIVE_ENV, timeout=_SUBPROCESS_TIMEOUT_SECONDS)
+        print(f"✅ Cloned {dest} from {url} (no content fetched yet).")
+        return
+
+    raise ValueError(f"❌ {dest} does not exist and neither 'source' nor 'url' was given.")
+
+
+def load_known_failures(cache_dir):
+    """Return the set of (root-relative) paths that previously failed to fetch."""
+    path = Path(cache_dir) / _FAILURES_FILENAME
+    if not path.is_file():
+        return set()
+    return set(json.loads(path.read_text()))
+
+
+def save_known_failures(cache_dir, failures):
+    """Persist the given set of (root-relative) paths as the known failures."""
+    path = Path(cache_dir) / _FAILURES_FILENAME
+    path.write_text(json.dumps(sorted(failures), indent=2) + "\n")
+
+
+def prefetch_pattern(dataset_root, pattern, subdir="", skip_set=(), match=None):
+    """Glob `dataset_root/subdir` for `pattern`, `datalad get` what's missing.
+
+    Generic core of a project's "fetch every small file the analysis reads"
+    step. Files already present on disk are never re-requested; among the
+    rest, only those whose root-relative path is not in `skip_set` (see
+    `load_known_failures`) are handed to `datalad_get` as one batch.
+
+    `match(path) -> bool` is an optional extra filter (e.g. narrow by
+    subject/session) applied to every glob hit before it counts as matched.
+
+    Returns `(already_present, newly_fetched, skipped, new_failures,
+    resolved)`: counts of files already on disk and newly fetched, a count of
+    files skipped because they were previously known to fail, and the sets of
+    root-relative paths that newly failed or newly succeeded this call — for
+    the caller to update its failure cache with `save_known_failures`.
+    """
+    root = Path(dataset_root)
+    target_dir = root / subdir if subdir else root
+    if not target_dir.is_dir():
+        return 0, 0, 0, set(), set()
+
+    matched = [p for p in target_dir.rglob(pattern) if match is None or match(p)]
+    rel_paths = {p: str(p.relative_to(root)) for p in matched}
+    missing = [p for p in matched if not p.is_file()]
+    already_present = len(matched) - len(missing)
+
+    to_attempt = [p for p in missing if rel_paths[p] not in skip_set]
+    skipped = len(missing) - len(to_attempt)
+
+    if to_attempt:
+        datalad_get([p.relative_to(root) for p in to_attempt], root)
+
+    newly_fetched, new_failures, resolved = 0, set(), set()
+    for p in to_attempt:
+        if p.is_file():
+            newly_fetched += 1
+            resolved.add(rel_paths[p])
+        else:
+            new_failures.add(rel_paths[p])
+
+    return already_present, newly_fetched, skipped, new_failures, resolved
+
+
+@task(
+    help={
+        "name": "Logical name of the dataset, as defined in the 'datasets' section of invoke.yaml.",
+        "source": "Path to an existing checkout to symlink instead of cloning.",
+    }
+)
+def install_dataset(c, name, source=None):
+    """📦 Make a datalad dataset checkout available: symlink existing, or clone.
+
+    Looks up `name` under `datasets` in invoke.yaml, then calls
+    `ensure_dataset` with the entry's `output_dir` as `dest` and `url`. A
+    `--source` argument (or the entry's own `source` key) symlinks an
+    existing checkout instead of cloning — this does not run `datalad get`,
+    so only content already present at `source` becomes visible.
+
+    Examples
+    --------
+    ```bash
+    inv datalad.install-dataset --name cneuromod
+    inv datalad.install-dataset --name cneuromod --source /data/cneuromod.all
+    ```
+    """
+    entry = _dataset_entry(c, name)
+    ensure_dataset(entry["output_dir"], url=entry["url"], source=source or entry["source"])
+
+
+@task(
+    help={
+        "name": "Logical name of the dataset, as defined in the 'datasets' section of invoke.yaml.",
+        "path": "Path (relative to the dataset root) to retrieve; defaults to the whole dataset.",
+        "recursive": "Recurse into nested subdatasets.",
+        "strict": "Raise instead of warning if retrieval fails.",
+    }
+)
+def get_data(c, name, path=None, recursive=False, strict=False):
+    """📥 Retrieve content for a datalad dataset (or a path within it).
+
+    Looks up `name` under `datasets` in invoke.yaml and runs `datalad get` at
+    its `output_dir`, narrowed to `path` when given. Tolerant of partial
+    failures by default — pass `--strict` to raise instead (e.g. in a smoke
+    test, which must fail loudly when retrieval doesn't work).
+
+    Examples
+    --------
+    ```bash
+    inv datalad.get-data --name cneuromod
+    inv datalad.get-data --name cneuromod --path sub-01/anat --strict
+    ```
+    """
+    entry = _dataset_entry(c, name)
+    target = path or "."
+    datalad_get(target, entry["output_dir"], recursive=recursive, strict=strict)
+
+
+@task(
+    help={
+        "name": "Logical name of the dataset, as defined in the 'datasets' section of invoke.yaml.",
+        "strict": "Raise instead of warning if the update fails.",
+    }
+)
+def update_dataset(c, name, strict=False):
+    """🔄 Advance a dataset's pin via `datalad update --merge`.
+
+    Looks up `name` under `datasets` in invoke.yaml and calls
+    `update_subdataset` on its `output_dir`. No-op if the dataset isn't
+    installed yet (no `.git`); use `install_dataset` first.
+
+    Examples
+    --------
+    ```bash
+    inv datalad.update-dataset --name cneuromod
+    ```
+    """
+    entry = _dataset_entry(c, name)
+    output_dir = Path(entry["output_dir"])
+    update_subdataset(output_dir.name, str(output_dir.parent), strict=strict)
+
 
 @task
 def import_file(c, name):
@@ -86,6 +406,7 @@ def import_file(c, name):
     inv datalad.import-file --name stimuli
     ```
     """
+    _require_datalad()
     files = c.config.get("files", {})
     if name not in files:
         raise ValueError(f"❌ No file config found for '{name}' in invoke.yaml.")
@@ -104,56 +425,3 @@ def import_file(c, name):
 
     c.run(f"datalad download-url -O {shlex.quote(output_file)} {shlex.quote(url)}")
     print(f"✅ Downloaded {name} to {output_file}")
-
-@task
-def import_archive(c, url, archive_name=None, target_dir=".", drop_archive=False):
-    """🗃️ Download and extract an archive via Datalad.
-
-    Retrieves a remote archive (e.g., from Zenodo or Figshare), extracts its contents
-    into the target directory, and optionally drops the original archive from the annex.
-
-    Parameters
-    ----------
-    c : invoke.Context
-        The Invoke context (automatically provided when running as a task).
-    url : str
-        The remote URL of the archive (e.g., `.zip`, `.tar.gz`).
-    archive_name : str, optional
-        Optional filename override. Defaults to the basename of the URL.
-    target_dir : str, optional
-        Directory to extract files into (default: current directory).
-    drop_archive : bool, optional
-        If True, drops the downloaded archive from the annex after extraction.
-
-    Notes
-    -----
-    Supported archive types: `.zip`, `.tar`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.7z`.
-
-    Examples
-    --------
-    ```bash
-    inv datalad.import-archive --url https://zenodo.org/record/XXXX/files/data.zip
-    inv datalad.import-archive --url https://figshare.com/... --target-dir ./data --drop-archive
-    ```
-    """
-    archive_name = archive_name or os.path.basename(url)
-    archive_path = os.path.join(target_dir, archive_name)
-
-    import_file(c, url, archive_path)
-
-    archive_exts = ['.zip', '.tar', '.tar.gz', '.tgz', '.tar.bz2', '.7z']
-    if not any(archive_path.endswith(ext) for ext in archive_exts):
-        print("⚠️ Skipping extraction — file does not appear to be a supported archive.")
-        return
-
-    print(f"📦 Extracting archive content into {target_dir}...")
-    c.run(
-        f"datalad add-archive-content --delete --extract "
-        f"{shlex.quote(archive_path)} -d {shlex.quote(target_dir)}"
-    )
-
-    if drop_archive:
-        print(f"🧹 Dropping archive from annex: {archive_path}")
-        c.run(f"datalad drop {shlex.quote(archive_path)}")
-
-    print("✅ Archive import complete.")

--- a/airoh/datalad.py
+++ b/airoh/datalad.py
@@ -7,10 +7,15 @@ if not shutil.which("datalad"):
         "Install it with: pip install airoh[datalad]"
     )
 
-from invoke import task
-import os
-import shlex
-from pathlib import Path
+# The rest of the imports stay below the guard so a missing datalad CLI raises
+# the message above rather than failing on some unrelated import first. isort
+# leaves them here — it never reorders across an intervening statement.
+import os  # noqa: E402
+import shlex  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+from invoke import task  # noqa: E402
+
 
 @task
 def get_data(c, name):
@@ -142,7 +147,10 @@ def import_archive(c, url, archive_name=None, target_dir=".", drop_archive=False
         return
 
     print(f"📦 Extracting archive content into {target_dir}...")
-    c.run(f"datalad add-archive-content --delete --extract {shlex.quote(archive_path)} -d {shlex.quote(target_dir)}")
+    c.run(
+        f"datalad add-archive-content --delete --extract "
+        f"{shlex.quote(archive_path)} -d {shlex.quote(target_dir)}"
+    )
 
     if drop_archive:
         print(f"🧹 Dropping archive from annex: {archive_path}")

--- a/airoh/provenance.py
+++ b/airoh/provenance.py
@@ -1,0 +1,464 @@
+# src/airoh/provenance.py
+"""📜 Lightweight provenance records for a pipeline's inputs and outputs.
+
+Two records, written by two tasks:
+
+* ``record_sources`` → ``source_data/MANIFEST.json``, written at the end of
+  ``fetch``: what each data asset actually resolved to (a URL, a real path
+  behind a symlink), how big it was, its checksum, and — when the asset lives
+  in a git or datalad repository — the commit it sat at.
+* ``record_run`` → ``output_data/PROVENANCE.json``, written at the end of
+  ``run``: the project commit, the environment, the manifest it consumed, and
+  a checksum of every file the run produced.
+
+Together they answer "which inputs produced these outputs, on which code, in
+which environment" without requiring datalad. When a project *is* tracked with
+datalad, these records are redundant but harmless — datalad remains the only
+thing that can actually *retrieve* a past state. See CLAUDE.md.
+
+Everything here is tolerant by design: a provenance record is documentation,
+never a precondition, so a missing file, an absent git binary or an unreadable
+asset is recorded as ``null`` with a warning. Nothing in this module raises.
+"""
+
+import hashlib
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from invoke import task
+
+# Hashing a multi-gigabyte asset would make every fetch crawl for a number
+# nobody reads, so files above this size record their metadata only. Override
+# with `provenance_hash_max_bytes` in invoke.yaml.
+DEFAULT_HASH_MAX_BYTES = 100 * 1024 * 1024
+
+# git is invoked for metadata only, so it should answer immediately. A bounded
+# timeout keeps an unreachable remote or a credential prompt from stalling a
+# fetch (git is also run with prompts disabled, below).
+_GIT_TIMEOUT_SECONDS = 15
+
+_GIT_ENV = dict(os.environ, GIT_TERMINAL_PROMPT="0")
+
+
+def _utc_now():
+    """Current UTC time as an ISO-8601 string."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _git(args, cwd):
+    """Return the stripped stdout of a git command, or None if it fails.
+
+    Tolerant: a missing git binary, a path outside any repository, or a
+    timeout all yield None rather than an exception.
+    """
+    try:
+        result = subprocess.run(
+            ["git"] + args, cwd=str(cwd), capture_output=True, text=True,
+            stdin=subprocess.DEVNULL, env=_GIT_ENV, timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def git_info(path):
+    """Describe the git state of the repository containing ``path``.
+
+    Returns a dict with ``commit``, ``branch``, ``remote`` and ``dirty``, or
+    None when ``path`` is not inside a git repository (or git is unavailable).
+    Used both for data assets — a symlinked datalad superdataset is a git
+    repository, so its commit pins the input state — and for the project repo
+    itself.
+    """
+    path = Path(path)
+    cwd = path if path.is_dir() else path.parent
+    if not cwd.exists():
+        return None
+    if _git(["rev-parse", "--is-inside-work-tree"], cwd) != "true":
+        return None
+    status = _git(["status", "--porcelain"], cwd)
+    return {
+        "toplevel": _git(["rev-parse", "--show-toplevel"], cwd),
+        "commit": _git(["rev-parse", "HEAD"], cwd),
+        "branch": _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd),
+        "remote": _git(["config", "--get", "remote.origin.url"], cwd),
+        "dirty": bool(status) if status is not None else None,
+    }
+
+
+def _datalad_id(path):
+    """The datalad dataset id at ``path``, or None if it is not one."""
+    config = Path(path) / ".datalad" / "config"
+    if not config.is_file():
+        return None
+    try:
+        text = config.read_text()
+    except OSError:
+        return None
+    match = re.search(r"^\s*id\s*=\s*(\S+)", text, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def sha256_file(path, max_bytes=DEFAULT_HASH_MAX_BYTES):
+    """Hex sha256 of ``path``, or None if it is too large or unreadable.
+
+    Files over ``max_bytes`` are deliberately skipped — see
+    ``DEFAULT_HASH_MAX_BYTES``.
+    """
+    path = Path(path)
+    try:
+        if path.stat().st_size > max_bytes:
+            return None
+        digest = hashlib.sha256()
+        with open(path, "rb") as handle:
+            for block in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(block)
+        return digest.hexdigest()
+    except OSError:
+        return None
+
+
+def describe_path(path, max_bytes=DEFAULT_HASH_MAX_BYTES):
+    """Describe one file or directory for a provenance record.
+
+    Records existence, size, mtime and (for files) a checksum, plus the git and
+    datalad state of whatever the path really points at. A symlink is resolved
+    first, so an asset linked to a checkout elsewhere on disk is attributed to
+    that checkout rather than to the link.
+    """
+    path = Path(path)
+    record = {
+        "path": str(path),
+        "exists": path.exists(),
+        "is_symlink": path.is_symlink(),
+        "resolved_path": None,
+        "size_bytes": None,
+        "mtime": None,
+        "sha256": None,
+        "git": None,
+        "datalad_id": None,
+    }
+    if not path.exists():
+        return record
+
+    resolved = path.resolve()
+    record["resolved_path"] = str(resolved)
+    try:
+        stat = resolved.stat()
+        record["mtime"] = datetime.fromtimestamp(
+            stat.st_mtime, timezone.utc).isoformat(timespec="seconds")
+        if resolved.is_file():
+            record["size_bytes"] = stat.st_size
+            record["sha256"] = sha256_file(resolved, max_bytes)
+    except OSError:
+        pass
+
+    record["git"] = git_info(resolved)
+    record["datalad_id"] = _datalad_id(resolved)
+    return record
+
+
+def _asset_entries(config):
+    """Yield ``(name, target_path, declared_source)`` for every data asset.
+
+    Covers both the ``files:`` section (assets with an ``output_file``) and the
+    ``datasets:`` section, which projects write either as a plain path string
+    or as a mapping with ``output_dir``/``output_file``.
+    """
+    for name, entry in (config.get("files") or {}).items():
+        if isinstance(entry, dict):
+            target = entry.get("output_file") or entry.get("output_dir")
+            yield name, target, entry.get("source") or entry.get("url")
+
+    for name, entry in (config.get("datasets") or {}).items():
+        if isinstance(entry, dict):
+            target = entry.get("output_dir") or entry.get("output_file")
+            yield name, target, entry.get("source") or entry.get("url")
+        else:
+            yield name, entry, None
+
+
+def _asset_mode(record, declared_source):
+    """How the asset got here: symlink, datalad, download, copy or local."""
+    if record["is_symlink"]:
+        return "symlink"
+    if record["datalad_id"]:
+        return "datalad"
+    if isinstance(declared_source, str) and declared_source.startswith(
+            ("http://", "https://", "ftp://")):
+        return "download"
+    return "copy" if declared_source else "local"
+
+
+def _drop_self_attribution(record, project_toplevel):
+    """Forget git state that just describes the project repo itself.
+
+    An asset downloaded into ``source_data/`` sits inside the project's own
+    repository, and reporting the project's commit as that asset's version
+    would be worse than reporting nothing — it looks like real input
+    provenance. Only an asset in a repository of its own keeps its git block.
+    """
+    git = record.get("git")
+    if git and project_toplevel and git.get("toplevel") == project_toplevel:
+        record["git"] = None
+    return record
+
+
+@task(help={"output": "Where to write the manifest (default: the "
+                      "`manifest_file` key in invoke.yaml)."})
+def record_sources(c, output=None):
+    """📜 Record what every data asset resolved to, into source_data/MANIFEST.json.
+
+    Call at the end of ``fetch``. For each asset declared under ``files:`` or
+    ``datasets:`` in invoke.yaml, records the path it landed at, what it really
+    points at, its size and checksum, and the git commit / datalad id of the
+    repository it belongs to — the part datalad would otherwise be needed for.
+
+    Tolerant: an asset that was never fetched is recorded as absent, and no
+    failure here can break a fetch.
+
+    Parameters
+    ----------
+    c : invoke.Context
+        The Invoke context.
+    output : str, optional
+        Manifest path. Defaults to the `manifest_file` key in invoke.yaml,
+        falling back to `source_data/MANIFEST.json`.
+
+    Examples
+    --------
+    ```bash
+    inv provenance.record-sources
+    ```
+    """
+    output_path = Path(output or c.config.get(
+        "manifest_file", "source_data/MANIFEST.json"))
+    max_bytes = c.config.get("provenance_hash_max_bytes", DEFAULT_HASH_MAX_BYTES)
+
+    project_toplevel = (git_info(Path.cwd()) or {}).get("toplevel")
+
+    assets = {}
+    for name, target, declared_source in _asset_entries(c.config):
+        if not target:
+            print(f"⚠️  Asset '{name}' declares no output path — skipping")
+            continue
+        record = describe_path(target, max_bytes)
+        record["declared_source"] = declared_source
+        record["mode"] = _asset_mode(record, declared_source)
+        assets[name] = _drop_self_attribution(record, project_toplevel)
+        if not record["exists"]:
+            print(f"⚠️  Asset '{name}' not present at {target} (recorded as absent)")
+
+    manifest = {
+        "schema": "airoh/manifest/1",
+        "recorded_at": _utc_now(),
+        "assets": assets,
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    print(f"📜 Recorded {len(assets)} asset(s) → {output_path}")
+    return output_path
+
+
+def _declared_dependencies():
+    """Package names this project declares, from pyproject.toml or requirements.txt.
+
+    Recording the version of every installed package would bury the handful
+    that matter in a few hundred transitive ones, so only declared
+    dependencies are versioned.
+    """
+    names = []
+    pyproject = Path("pyproject.toml")
+    if pyproject.is_file():
+        names = _parse_pyproject_dependencies(pyproject)
+    if not names:
+        requirements = Path("requirements.txt")
+        if requirements.is_file():
+            names = parse_requirements(requirements)
+    return names
+
+
+def _parse_pyproject_dependencies(path):
+    """Package names in ``[project].dependencies``.
+
+    Uses tomllib/tomli when available (tomllib is stdlib from 3.11) and falls
+    back to reading the ``dependencies = [...]`` array directly, so airoh keeps
+    its single-dependency footprint on older interpreters.
+    """
+    try:
+        try:
+            import tomllib
+        except ImportError:
+            import tomli as tomllib
+        with open(path, "rb") as handle:
+            data = tomllib.load(handle)
+        return [requirement_name(spec)
+                for spec in data.get("project", {}).get("dependencies", [])]
+    except Exception:
+        pass
+
+    try:
+        text = path.read_text()
+    except OSError:
+        return []
+    match = re.search(r"^dependencies\s*=\s*\[(.*?)\]", text, re.MULTILINE | re.DOTALL)
+    if not match:
+        return []
+    return [requirement_name(spec)
+            for spec in re.findall(r"[\"']([^\"']+)[\"']", match.group(1))]
+
+
+def requirement_name(spec):
+    """Bare package name from a requirement spec ('numpy>=1.3' → 'numpy')."""
+    return re.split(r"[\[<>=!~;\s]", spec.strip(), maxsplit=1)[0].lower()
+
+
+def parse_requirements(path):
+    """Package names in a requirements file, ignoring comments and flags."""
+    names = []
+    try:
+        lines = Path(path).read_text().splitlines()
+    except OSError:
+        return names
+    for line in lines:
+        line = line.split("#", 1)[0].strip()
+        if not line or line.startswith("-"):
+            continue
+        names.append(requirement_name(line))
+    return names
+
+
+def _environment():
+    """Python, platform and declared-dependency versions."""
+    from importlib.metadata import PackageNotFoundError, version
+
+    packages = {}
+    for name in sorted(set(_declared_dependencies())):
+        try:
+            packages[name] = version(name)
+        except PackageNotFoundError:
+            packages[name] = None
+    try:
+        packages.setdefault("airoh", version("airoh"))
+    except PackageNotFoundError:
+        pass
+
+    lockfiles = {}
+    for name in ("uv.lock", "requirements.txt", "environment.yml"):
+        if Path(name).is_file():
+            lockfiles[name] = sha256_file(name)
+
+    return {
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "packages": packages,
+        "lockfiles": lockfiles,
+    }
+
+
+def _output_files(output_dir, max_bytes, exclude):
+    """Checksum every file the pipeline produced under ``output_dir``.
+
+    The record itself, dotfiles and CONTENT.md are repository bookkeeping that
+    lives in the output folder without being an output of the run.
+    """
+    outputs = {}
+    root = Path(output_dir)
+    if not root.is_dir():
+        return outputs
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path == exclude:
+            continue
+        if path.name == "CONTENT.md" or any(
+                part.startswith(".") for part in path.relative_to(root).parts):
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        outputs[str(path.relative_to(root))] = {
+            "size_bytes": size,
+            "sha256": sha256_file(path, max_bytes),
+        }
+    return outputs
+
+
+@task(help={"output": "Where to write the record (default: the "
+                      "`provenance_file` key in invoke.yaml).",
+            "tasks": "Comma-separated names of the tasks that ran."})
+def record_run(c, output=None, tasks=None):
+    """📜 Record what produced the current outputs, into output_data/PROVENANCE.json.
+
+    Call at the end of ``run``. Records the project's own git commit and dirty
+    flag, the environment, a checksum of the input manifest (plus an inlined
+    copy of each asset's commit and checksum, so the record still means
+    something if the manifest is lost), and the size and checksum of every
+    output file.
+
+    This file changes on every run — that is the point of it. Do not try to
+    make it stable; if the churn is unwanted, the answer is to run less often,
+    not to record less.
+
+    Tolerant: nothing here can break a run.
+
+    Parameters
+    ----------
+    c : invoke.Context
+        The Invoke context.
+    output : str, optional
+        Record path. Defaults to the `provenance_file` key in invoke.yaml,
+        falling back to `output_data/PROVENANCE.json`.
+    tasks : str, optional
+        Comma-separated names of the tasks that ran, recorded as-is.
+
+    Examples
+    --------
+    ```bash
+    inv provenance.record-run --tasks run-qc-measures,run-notebooks
+    ```
+    """
+    output_path = Path(output or c.config.get(
+        "provenance_file", "output_data/PROVENANCE.json"))
+    max_bytes = c.config.get("provenance_hash_max_bytes", DEFAULT_HASH_MAX_BYTES)
+    manifest_path = Path(c.config.get("manifest_file", "source_data/MANIFEST.json"))
+    output_dir = c.config.get("output_data_dir", "output_data")
+
+    inputs = {"manifest_file": str(manifest_path), "manifest_sha256": None,
+              "assets": {}}
+    if manifest_path.is_file():
+        inputs["manifest_sha256"] = sha256_file(manifest_path, max_bytes)
+        try:
+            manifest = json.loads(manifest_path.read_text())
+            for name, record in (manifest.get("assets") or {}).items():
+                inputs["assets"][name] = {
+                    "resolved_path": record.get("resolved_path"),
+                    "sha256": record.get("sha256"),
+                    "commit": (record.get("git") or {}).get("commit"),
+                }
+        except (OSError, ValueError):
+            print(f"⚠️  Could not read {manifest_path} — recording its hash only")
+    else:
+        print(f"⚠️  No manifest at {manifest_path} — run `invoke fetch` to create it")
+
+    record = {
+        "schema": "airoh/provenance/1",
+        "recorded_at": _utc_now(),
+        "tasks": [name.strip() for name in tasks.split(",")] if tasks else None,
+        "command": " ".join(sys.argv),
+        "repository": git_info(Path.cwd()),
+        "environment": _environment(),
+        "inputs": inputs,
+        "outputs": _output_files(output_dir, max_bytes, output_path),
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+    print(f"📜 Recorded {len(record['outputs'])} output(s) → {output_path}")
+    return output_path

--- a/airoh/verify.py
+++ b/airoh/verify.py
@@ -1,0 +1,692 @@
+# src/airoh/verify.py
+"""🔍 Consistency checks between a project's code, config, data and docs.
+
+A reproducible pipeline drifts from its own documentation quietly: a task is
+renamed and the README still lists the old one, a step stops fetching something
+and the docstring still says it does, an output appears and CONTENT.md never
+hears about it. None of that breaks a run, so nothing catches it — which is
+exactly why it needs a prespecified check rather than a habit.
+
+``invoke verify`` runs a flat list of independent checks and exits non-zero if
+any of them FAIL. There is deliberately no ordering, no dependency graph and no
+caching here: each check reads the repository as it currently is and reports.
+
+Each check returns a :class:`Finding` with one of four statuses:
+
+* ``PASS``  — the check ran and found nothing.
+* ``WARN``  — something worth looking at that is legitimately transient (an
+  output that has not been produced yet, say).
+* ``FAIL``  — a real inconsistency. Exits non-zero.
+* ``SKIP``  — the check could not run here (no git, no README, no linter
+  configured). Never a failure: a project without a README is not broken.
+
+Checks are configured under an optional ``verify:`` block in invoke.yaml::
+
+    verify:
+      skip_checks: [lint]
+      ignore_paths: [output_data/figures/*.png]
+      max_tracked_bytes: 10000000
+
+This complements the ``/verify`` skill, which runs these checks first and then
+reads the prose for claims about behaviour that no regex can evaluate.
+"""
+
+import ast
+import fnmatch
+import re
+import shutil
+import subprocess
+from collections import namedtuple
+from pathlib import Path
+
+from invoke import Exit, task
+
+from airoh.provenance import parse_requirements, requirement_name
+
+#: One check's verdict. ``details`` is a list of strings printed beneath it.
+Finding = namedtuple("Finding", "check status message details")
+
+PASS, WARN, FAIL, SKIP = "PASS", "WARN", "FAIL", "SKIP"
+
+_STATUS_ICON = {PASS: "✅", WARN: "⚠️ ", FAIL: "❌", SKIP: "🫧"}
+
+# Git tracks history forever, so a large file committed once is committed for
+# good. Projects that legitimately track something big raise the ceiling in
+# invoke.yaml rather than deleting the check.
+DEFAULT_MAX_TRACKED_BYTES = 10 * 1024 * 1024
+
+# Extensions that essentially never belong in git for an analysis project.
+RISKY_EXTENSIONS = (".nii", ".nii.gz", ".mgz", ".h5", ".hdf5", ".mat", ".npy",
+                    ".npz", ".zip", ".tar", ".tar.gz", ".tgz", ".dcm", ".sqlite")
+
+# Files whose prose is checked for path references.
+DOC_FILES = ("README.md", "CLAUDE.md", "source_data/CONTENT.md",
+             "output_data/CONTENT.md")
+
+# Records written by airoh.provenance, not data the project is expected to
+# describe in CONTENT.md.
+_PROVENANCE_NAMES = ("MANIFEST.json", "PROVENANCE.json")
+
+# Keys airoh's own tasks read straight from the config, so a project's tasks.py
+# never mentions them and they must not be reported as unused.
+AIROH_CONFIG_KEYS = {"files", "datasets", "verify", "manifest_file",
+                     "provenance_file", "provenance_hash_max_bytes"}
+
+
+def _ok(check, message):
+    return Finding(check, PASS, message, [])
+
+
+def _skip(check, message):
+    return Finding(check, SKIP, message, [])
+
+
+class Project:
+    """The paths and settings the checks read, resolved once."""
+
+    def __init__(self, config, root=None):
+        self.config = config
+        self.root = Path(root or Path.cwd())
+        self.source_dir = self.root / config.get("source_data_dir", "source_data")
+        self.output_dir = self.root / config.get("output_data_dir", "output_data")
+        self.tasks_file = self.root / "tasks.py"
+        self.invoke_yaml = self.root / "invoke.yaml"
+        settings = config.get("verify") or {}
+        self.skip_checks = set(settings.get("skip_checks") or [])
+        self.ignore_paths = list(settings.get("ignore_paths") or [])
+        self.max_tracked_bytes = settings.get(
+            "max_tracked_bytes", DEFAULT_MAX_TRACKED_BYTES)
+        self._basenames = None
+
+    def basenames(self):
+        """Every file and directory name in the repo, indexed once.
+
+        Docs name a file by its bare basename far more often than by its full
+        path (`floc_avgtsnr.png`, not `output_data/figures/tsnr_maps/…`), so
+        resolving those needs a name index rather than a path join.
+        """
+        if self._basenames is None:
+            skip = {".git", ".venv", "__pycache__", "node_modules",
+                    ".ruff_cache", ".pytest_cache"}
+            names = set()
+            stack = [self.root]
+            while stack:
+                for entry in _iterdir(stack.pop()):
+                    if entry.name in skip:
+                        continue
+                    names.add(entry.name)
+                    if entry.is_dir() and not entry.is_symlink():
+                        stack.append(entry)
+            self._basenames = names
+        return self._basenames
+
+    def read(self, relative):
+        """Text of a repo-relative file, or None if it is absent/unreadable."""
+        try:
+            return (self.root / relative).read_text()
+        except (OSError, UnicodeDecodeError):
+            return None
+
+    def is_ignored(self, relative):
+        """Whether a repo-relative path is exempted by `verify.ignore_paths`."""
+        return any(fnmatch.fnmatch(relative, pattern)
+                   for pattern in self.ignore_paths)
+
+
+# --------------------------------------------------------------------------- #
+# Reading the project
+# --------------------------------------------------------------------------- #
+def task_names(tasks_file):
+    """Names of the invoke tasks defined in ``tasks.py``, hyphenated.
+
+    Parsed from the source rather than by importing it: verify must work on a
+    project whose tasks.py imports something unavailable. Only tasks defined in
+    the file are seen — namespaced tasks pulled in from airoh are not, and the
+    README is not expected to list them.
+    """
+    try:
+        tree = ast.parse(Path(tasks_file).read_text())
+    except (OSError, SyntaxError):
+        return None
+    names = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            target = decorator.func if isinstance(decorator, ast.Call) else decorator
+            if isinstance(target, ast.Name) and target.id == "task":
+                names.append(node.name.replace("_", "-"))
+                break
+    return sorted(set(names))
+
+
+def config_keys_used(tasks_file):
+    """Config keys ``tasks.py`` reads via ``c.config.get("…")``.
+
+    Only a ``.get`` called directly on ``…​.config`` counts. Chained lookups
+    such as ``c.config.get("datasets", {}).get("name", {})`` read *into* a
+    value, and their inner keys are not top-level invoke.yaml keys.
+    """
+    try:
+        tree = ast.parse(Path(tasks_file).read_text())
+    except (OSError, SyntaxError):
+        return set()
+    keys = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        receiver = node.func.value
+        is_config = isinstance(receiver, ast.Attribute) and receiver.attr == "config"
+        if node.func.attr != "get" or not node.args or not is_config:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            keys.add(first.value)
+    return keys
+
+
+def string_literals(tasks_file):
+    """Every string literal in ``tasks.py``.
+
+    Used only to decide whether a declared key is unused: a key can be handed
+    to airoh by name rather than read directly (``keys=["source_data_dir"]``),
+    and that still counts as used.
+    """
+    try:
+        tree = ast.parse(Path(tasks_file).read_text())
+    except (OSError, SyntaxError):
+        return set()
+    return {node.value for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)}
+
+
+def config_keys_declared(invoke_yaml):
+    """Top-level keys declared in invoke.yaml.
+
+    Read straight from the file rather than from the loaded config, which also
+    holds invoke's own defaults (``run``, ``timeouts``, …) and would make every
+    project look full of unused keys.
+    """
+    try:
+        text = Path(invoke_yaml).read_text()
+    except OSError:
+        return None
+    return {match.group(1)
+            for match in re.finditer(r"^([A-Za-z_][A-Za-z0-9_]*):", text, re.MULTILINE)}
+
+
+def _git_tracked_files(root):
+    """Repo-relative paths git tracks, or None outside a repository."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z"], cwd=str(root), capture_output=True,
+            text=True, stdin=subprocess.DEVNULL, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return [name for name in result.stdout.split("\0") if name]
+
+
+# --------------------------------------------------------------------------- #
+# Checks
+# --------------------------------------------------------------------------- #
+def check_task_list(project):
+    """Every task defined in tasks.py is documented, and vice versa."""
+    defined = task_names(project.tasks_file)
+    if defined is None:
+        return _skip("task_list", "no readable tasks.py")
+
+    invoked, mentioned = set(), set()
+    for doc in ("README.md", "CLAUDE.md"):
+        text = project.read(doc)
+        if text:
+            invoked |= documented_task_names(text)
+            mentioned |= backticked_names(text)
+
+    if not invoked:
+        return _skip("task_list", "no `invoke <task>` references in README/CLAUDE")
+
+    # Naming a task anywhere (a README table row) documents it; only an
+    # explicit `invoke foo` claims that a task by that name exists.
+    undocumented = sorted(set(defined) - invoked - mentioned)
+    phantom = sorted(invoked - set(defined))
+    details = ([f"defined but not documented: {name}" for name in undocumented]
+               + [f"documented but not defined: {name}" for name in phantom])
+    if details:
+        return Finding("task_list", FAIL,
+                       "task list in the docs does not match tasks.py", details)
+    return _ok("task_list", f"{len(defined)} task(s) documented")
+
+
+def documented_task_names(text):
+    """Task names documented as ``invoke <name>`` in ``text``.
+
+    Only code spans and fenced blocks are read: a sentence about "reusable
+    invoke tasks" is prose, not a claim that a task named ``tasks`` exists. The
+    lookahead drops placeholders like ``invoke fetch-{name}``, which document a
+    naming convention rather than one concrete task.
+    """
+    spans = re.findall(r"```(.*?)```", text, re.DOTALL)
+    spans += re.findall(r"`([^`\n]+)`", text)
+    names = set()
+    for span in spans:
+        names |= set(re.findall(r"\binvoke\s+([a-z][a-z0-9-]*[a-z0-9])(?![\w{-])", span))
+    return names
+
+
+def backticked_names(text):
+    """Code spans that are bare task-like names, e.g. `run-simulation`.
+
+    A README often documents a task in a table cell rather than as a command,
+    which still counts as documenting it.
+    """
+    return {token for token in re.findall(r"`([a-z][a-z0-9-]*[a-z0-9])`", text)}
+
+
+def check_dependencies(project):
+    """pyproject.toml, requirements.txt and environment.yml declare the same packages."""
+    from airoh.provenance import _parse_pyproject_dependencies
+
+    declared = {}
+    if (project.root / "pyproject.toml").is_file():
+        declared["pyproject.toml"] = set(
+            _parse_pyproject_dependencies(project.root / "pyproject.toml"))
+    if (project.root / "requirements.txt").is_file():
+        declared["requirements.txt"] = set(
+            parse_requirements(project.root / "requirements.txt"))
+    if (project.root / "environment.yml").is_file():
+        declared["environment.yml"] = _conda_dependencies(
+            project.root / "environment.yml")
+
+    declared = {name: packages for name, packages in declared.items() if packages}
+    if len(declared) < 2:
+        return _skip("dependencies", "fewer than two dependency files to compare")
+
+    union = set().union(*declared.values())
+    details = []
+    for name, packages in sorted(declared.items()):
+        missing = sorted(union - packages)
+        if missing:
+            details.append(f"{name} is missing: {', '.join(missing)}")
+    if details:
+        return Finding("dependencies", FAIL,
+                       "dependency files disagree — an install path is broken",
+                       details)
+    return _ok("dependencies", f"{len(union)} package(s) agree across {len(declared)} file(s)")
+
+
+def _conda_dependencies(path):
+    """Package names under `dependencies:` in an environment.yml.
+
+    Block-aware: entries under `channels:` are not packages, and the `pip:`
+    sub-list holds packages but is not one itself.
+    """
+    try:
+        text = Path(path).read_text()
+    except OSError:
+        return set()
+    names, in_dependencies = set(), False
+    for line in text.splitlines():
+        if re.match(r"^\S", line):
+            in_dependencies = line.startswith("dependencies:")
+            continue
+        stripped = line.strip()
+        if not in_dependencies or not stripped.startswith("- "):
+            continue
+        candidate = requirement_name(stripped[2:].rstrip(":"))
+        if candidate and candidate not in ("pip", "python"):
+            names.add(candidate)
+    return names
+
+
+def check_doc_paths(project):
+    """Paths named in the docs exist on disk."""
+    missing_hard, missing_soft = [], []
+    for doc in DOC_FILES:
+        text = project.read(doc)
+        if text is None:
+            continue
+        # A CONTENT.md names its own folder's entries by bare filename, so
+        # paths resolve relative to the document as well as to the repo root.
+        doc_dir = project.root / Path(doc).parent
+        for candidate in _path_candidates(text):
+            if project.is_ignored(candidate) or _resolves(project, doc_dir, candidate):
+                continue
+            if _is_soft(project, doc, candidate):
+                missing_soft.append(f"{doc}: {candidate} (not present yet)")
+            else:
+                missing_hard.append(f"{doc}: {candidate}")
+
+    if missing_hard:
+        return Finding("doc_paths", FAIL, "docs reference paths that do not exist",
+                       missing_hard + missing_soft)
+    if missing_soft:
+        return Finding("doc_paths", WARN,
+                       "docs reference data paths not present yet "
+                       "(run `invoke fetch` / `invoke run`?)", missing_soft)
+    return _ok("doc_paths", "every path named in the docs exists")
+
+
+def _path_candidates(text):
+    """Repo-relative paths mentioned in backticks in ``text``.
+
+    Conservative on purpose: a token counts only if it looks like a path (a
+    slash, or a known file extension) and cannot be something else — a URL, a
+    shell command, a git remote.
+    """
+    candidates = set()
+    for token in re.findall(r"`([^`\n]+)`", text):
+        token = token.strip().rstrip(",.;:")
+        if not token or any(char in token for char in " \t@{}…") or "://" in token:
+            continue
+        if token.startswith(("/", "~", "-")) or ".." in token:
+            continue
+        has_extension = re.search(
+            r"\.(py|md|ipynb|yaml|yml|toml|txt|json|tsv|csv|png|svg|lock|cfg)$", token)
+        if "/" not in token and not has_extension:
+            continue
+        # Strip a leading "./" as a prefix, not as a character set — lstrip
+        # would also eat the dot of a path like ".claude/skills".
+        if token.startswith("./"):
+            token = token[2:]
+        candidates.add(token.rstrip("/"))
+    return sorted(candidates)
+
+
+def _iterdir(path):
+    """Entries of a directory, empty on any error."""
+    try:
+        return list(path.iterdir())
+    except OSError:
+        return []
+
+
+def _resolves(project, doc_dir, candidate):
+    """Whether a documented path can be found, from the root or from the doc.
+
+    A candidate with a directory component is resolved as a path; a bare
+    basename is looked up in the repo's name index, since docs rarely spell
+    out where a file lives.
+    """
+    is_glob = any(char in candidate for char in "*?[")
+    if "/" not in candidate:
+        # A bare pattern like `*_bold.json` names a file-naming convention, not
+        # a location — there is nothing to resolve.
+        return is_glob or candidate in project.basenames()
+    if is_glob:
+        return _glob_hit(project.root, candidate) or _glob_hit(doc_dir, candidate)
+    return (project.root / candidate).exists() or (doc_dir / candidate).exists()
+
+
+def _glob_hit(root, pattern):
+    """Whether a glob pattern matches anything under ``root``."""
+    try:
+        return any(root.glob(pattern))
+    except (ValueError, OSError):
+        return True
+
+
+def _is_soft(project, doc, candidate):
+    """Whether a missing path is a warning rather than a failure.
+
+    Three cases are legitimately absent: data that has not been fetched or
+    produced yet, a directory the docs tell the reader to *create* (the
+    template's `tests/`), and a bare filename, which claims that a file exists
+    somewhere rather than that it exists at a particular place — `MANIFEST.json`
+    before the first fetch, say. A missing path *with a directory component* is
+    a real failure: it points somewhere specific, and nothing is there.
+    """
+    for data_dir in (project.source_dir, project.output_dir):
+        if candidate.startswith(data_dir.name + "/") or data_dir.name in doc:
+            return True
+    return "/" not in candidate or "." not in Path(candidate).name
+
+
+def check_content_md(project):
+    """Everything in the data folders is described in that folder's CONTENT.md."""
+    details, checked = [], 0
+    for data_dir in (project.source_dir, project.output_dir):
+        if not data_dir.is_dir():
+            continue
+        content = project.read(Path(data_dir.name) / "CONTENT.md")
+        if content is None:
+            details.append(f"{data_dir.name}/CONTENT.md is missing")
+            continue
+        checked += 1
+        for entry in sorted(data_dir.iterdir()):
+            if entry.name.startswith(".") or entry.name in _PROVENANCE_NAMES:
+                continue
+            if entry.name == "CONTENT.md":
+                continue
+            if entry.name not in content:
+                details.append(
+                    f"{data_dir.name}/{entry.name} is not described in "
+                    f"{data_dir.name}/CONTENT.md")
+
+    if not checked and not details:
+        return _skip("content_md", "no data folders to check")
+    if details:
+        return Finding("content_md", FAIL,
+                       "data folders and their CONTENT.md disagree", details)
+    return _ok("content_md", "data folders match their CONTENT.md")
+
+
+def check_config_keys(project):
+    """tasks.py and invoke.yaml agree on which config keys exist."""
+    declared = config_keys_declared(project.invoke_yaml)
+    if declared is None:
+        return _skip("config_keys", "no readable invoke.yaml")
+    used = config_keys_used(project.tasks_file)
+    if not used:
+        return _skip("config_keys", "tasks.py reads no config keys")
+
+    details = [f"read in tasks.py but not declared in invoke.yaml: {key}"
+               for key in sorted(used - declared)]
+    if details:
+        return Finding("config_keys", FAIL,
+                       "tasks.py reads config keys invoke.yaml does not declare",
+                       details)
+    unused = sorted(declared - used - AIROH_CONFIG_KEYS
+                    - string_literals(project.tasks_file))
+    if unused:
+        return Finding("config_keys", WARN,
+                       "invoke.yaml declares keys nothing reads",
+                       [f"unused: {key}" for key in unused])
+    return _ok("config_keys", f"{len(used)} config key(s) declared and read")
+
+
+def check_tracked_size(project):
+    """No oversized or binary-by-nature file is tracked in git."""
+    tracked = _git_tracked_files(project.root)
+    if tracked is None:
+        return _skip("tracked_size", "not a git repository")
+
+    oversized, risky = [], []
+    for name in tracked:
+        if project.is_ignored(name):
+            continue
+        # Dot-directories hold tooling (.claude/ skills, .github/ workflows),
+        # not data — an archive there is deliberate.
+        is_tooling = name.startswith(".")
+        if name.lower().endswith(RISKY_EXTENSIONS) and not is_tooling:
+            risky.append(f"risky file type tracked: {name}")
+        path = project.root / name
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        if size > project.max_tracked_bytes:
+            oversized.append(f"{name} is {size // 1024 // 1024} MB")
+
+    if oversized or risky:
+        return Finding("tracked_size", FAIL,
+                       "git tracks files that do not belong in git",
+                       risky + oversized)
+    return _ok("tracked_size", f"{len(tracked)} tracked file(s) within limits")
+
+
+def check_provenance(project):
+    """The provenance records exist and are not older than what they describe."""
+    manifest = project.root / project.config.get(
+        "manifest_file", "source_data/MANIFEST.json")
+    record = project.root / project.config.get(
+        "provenance_file", "output_data/PROVENANCE.json")
+
+    details = []
+    if _has_data(project.source_dir) and not manifest.is_file():
+        details.append(f"{manifest.name} is missing though source data is present "
+                       "— run `invoke fetch`")
+    if _has_data(project.output_dir):
+        if not record.is_file():
+            details.append(f"{record.name} is missing though outputs are present "
+                           "— run `invoke run`")
+        elif _newest_mtime(project.output_dir, record) > record.stat().st_mtime:
+            details.append(f"{record.name} is older than the outputs it describes "
+                           "— re-run `invoke run`")
+
+    if not manifest.is_file() and not record.is_file() and not details:
+        return _skip("provenance", "no provenance records and no data yet")
+    if details:
+        return Finding("provenance", WARN, "provenance records are stale or missing",
+                       details)
+    return _ok("provenance", "provenance records are present and current")
+
+
+def _has_data(data_dir):
+    """Whether a data folder holds anything beyond its own bookkeeping."""
+    if not data_dir.is_dir():
+        return False
+    return any(entry.name not in _PROVENANCE_NAMES + ("CONTENT.md",)
+               and not entry.name.startswith(".")
+               for entry in data_dir.iterdir())
+
+
+def _newest_mtime(data_dir, exclude):
+    """Newest mtime of an actual output under ``data_dir``.
+
+    Repository bookkeeping that happens to live in the data folder — the record
+    itself, dotfiles, CONTENT.md — is not an output, and editing it must not
+    make the provenance record look stale.
+    """
+    newest = 0
+    for path in data_dir.rglob("*"):
+        if not path.is_file() or path == exclude or path.name == "CONTENT.md":
+            continue
+        if any(part.startswith(".") for part in path.relative_to(data_dir).parts):
+            continue
+        try:
+            newest = max(newest, path.stat().st_mtime)
+        except OSError:
+            continue
+    return newest
+
+
+def check_lint(project):
+    """The project's configured linter passes."""
+    pyproject = project.read("pyproject.toml") or ""
+    if "[tool.ruff" in pyproject:
+        command, binary = ["ruff", "check", "."], "ruff"
+    elif (project.root / "setup.cfg").is_file() and "[flake8]" in (
+            project.read("setup.cfg") or ""):
+        command, binary = ["flake8"], "flake8"
+    else:
+        return _skip("lint", "no linter configured")
+
+    if shutil.which(binary) is None:
+        return _skip("lint", f"{binary} is configured but not on PATH")
+    try:
+        result = subprocess.run(command, cwd=str(project.root), capture_output=True,
+                                text=True, stdin=subprocess.DEVNULL, timeout=300)
+    except (OSError, subprocess.SubprocessError) as error:
+        return _skip("lint", f"could not run {binary}: {error}")
+    if result.returncode != 0:
+        return Finding("lint", FAIL, f"{binary} reported problems",
+                       result.stdout.strip().splitlines()[:20])
+    return _ok("lint", f"{binary} is clean")
+
+
+#: Every check, in report order. Add to this list to add a check.
+CHECKS = (
+    check_content_md,
+    check_task_list,
+    check_dependencies,
+    check_doc_paths,
+    check_config_keys,
+    check_tracked_size,
+    check_provenance,
+    check_lint,
+)
+
+
+def run_checks(config, root=None, skip=()):
+    """Run every check and return the findings, in report order.
+
+    Importable so a project (or a test) can consume the findings directly
+    rather than parsing printed output.
+    """
+    project = Project(config, root)
+    skip = set(skip) | project.skip_checks
+    findings = []
+    for check in CHECKS:
+        name = check.__name__.replace("check_", "")
+        if name in skip:
+            findings.append(_skip(name, "skipped by configuration"))
+            continue
+        try:
+            findings.append(check(project))
+        except Exception as error:  # a broken check must not mask the others
+            findings.append(Finding(name, SKIP, f"check raised {error!r}", []))
+    return findings
+
+
+@task(help={
+    "skip": "Comma-separated check names to skip (also settable under "
+            "`verify: skip_checks:` in invoke.yaml).",
+    "strict": "Treat warnings as failures.",
+})
+def verify(c, skip=None, strict=False):
+    """🔍 Check that code, config, data and docs still agree.
+
+    Runs a flat list of independent checks — see the module docstring for what
+    each one covers — prints a report, and exits non-zero if any FAIL (or, with
+    --strict, any WARN). Never called by `run`: reproduction should not depend
+    on documentation hygiene. Run it before committing, and in CI.
+
+    The checks are mechanical. For claims that only prose can make — "this step
+    never pulls data", "this default is 30" — use the `/verify` skill, which
+    runs these first and then reads the docs against the code.
+
+    Parameters
+    ----------
+    c : invoke.Context
+        The Invoke context.
+    skip : str, optional
+        Comma-separated check names to skip.
+    strict : bool, optional
+        Treat warnings as failures (default: False).
+
+    Examples
+    --------
+    ```bash
+    inv verify
+    inv verify --skip lint --strict
+    ```
+    """
+    skip_names = [name.strip() for name in (skip or "").split(",") if name.strip()]
+    findings = run_checks(c.config, skip=skip_names)
+
+    for finding in findings:
+        print(f"{_STATUS_ICON[finding.status]} {finding.check}: {finding.message}")
+        for detail in finding.details:
+            print(f"      · {detail}")
+
+    failed = [f for f in findings if f.status == FAIL]
+    warned = [f for f in findings if f.status == WARN]
+    passed = [f for f in findings if f.status == PASS]
+    print(f"\n{len(passed)} passed, {len(warned)} warning(s), {len(failed)} failure(s)")
+
+    if failed or (strict and warned):
+        raise Exit("❌ verify failed — the docs and the code disagree", code=1)
+    print("✅ verify passed")

--- a/airoh/verify.py
+++ b/airoh/verify.py
@@ -70,7 +70,9 @@ _PROVENANCE_NAMES = ("MANIFEST.json", "PROVENANCE.json")
 # Keys airoh's own tasks read straight from the config, so a project's tasks.py
 # never mentions them and they must not be reported as unused.
 AIROH_CONFIG_KEYS = {"files", "datasets", "verify", "manifest_file",
-                     "provenance_file", "provenance_hash_max_bytes"}
+                     "provenance_file", "provenance_hash_max_bytes",
+                     "output_data_dir", "source_data_dir", "notebooks_dir",
+                     "figures_dir", "docker_image", "docker_archive"}
 
 
 def _ok(check, message):
@@ -335,7 +337,11 @@ def _conda_dependencies(path):
         stripped = line.strip()
         if not in_dependencies or not stripped.startswith("- "):
             continue
-        candidate = requirement_name(stripped[2:].rstrip(":"))
+        item = stripped[2:].rstrip(":")
+        if item.startswith("-"):
+            # A pip flag (`-e .`, `-r requirements.txt`), not a package.
+            continue
+        candidate = requirement_name(item)
         if candidate and candidate not in ("pip", "python"):
             names.add(candidate)
     return names

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -1,1 +1,1 @@
-template_repo: https://github.com/airoh-pipeline/airoh-template
+template_repo: https://github.com/airoh-pipeline/airoh-mini

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "airoh"
-version = "0.3.2"
+version = "0.4.0"
 description = "A lightweight task library for reproducible workflows"
 authors = [{ name = "Lune Bellec", email = "lune.bellec@umontreal.ca" }]
 readme = "README.md"
@@ -23,7 +23,10 @@ Issues = "https://github.com/airoh-pipeline/airoh/issues"
 [tool.ruff]
 line-length = 100
 target-version = "py38"
-select = ["I"]  # E = pycodestyle, F = pyflakes, I = isort
+
+[tool.ruff.lint]
+# E = pycodestyle, F = pyflakes, I = isort — matches the downstream projects.
+select = ["E", "F", "I"]
 
 [tool.hatch.envs.dev]
 dependencies = [

--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,6 @@
 from invoke import task
 
+
 @task
 def make_docs(c, url_logo=None):
     if not url_logo:

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_airoh_template_smoke.py
+++ b/tests/test_airoh_template_smoke.py
@@ -1,18 +1,21 @@
-import tempfile
-import subprocess
-import shutil
 import os
+import subprocess
+import tempfile
 from pathlib import Path
+
 import pytest
+import yaml
 from invoke import Context
 from invoke.config import Config
-import yaml
+
 
 @pytest.mark.integration
 def test_airoh_template_smoke():
     """
-    Clone the airoh-template repo (from invoke config), run setup, fetch, and run.
-    Docker is skipped by default.
+    Clone the template repo (from invoke config), fetch, run, and verify.
+
+    Needs network access and installs into the ambient environment, hence the
+    `integration` marker: run with `pytest -m integration`.
     """
     invoke_config_path = Path(__file__).parents[1] / "invoke.yaml"
     with open(invoke_config_path, "r") as f:
@@ -29,9 +32,9 @@ def test_airoh_template_smoke():
         env = {"PYTHONUNBUFFERED": "1", **os.environ}
 
         # 👇 Install local airoh from this repo before calling invoke in the template
-        subprocess.run(["pip", "install", "-e", str(Path(__file__).parents[1])], check=True, env=env)
+        subprocess.run(["pip", "install", "-e", str(Path(__file__).parents[1])],
+                       check=True, env=env)
 
-        subprocess.run(["invoke", "setup"], cwd=tmpdir_path, check=True, env=env)
         subprocess.run(["invoke", "fetch"], cwd=tmpdir_path, check=True, env=env)
         subprocess.run(["invoke", "run"], cwd=tmpdir_path, check=True, env=env)
 
@@ -39,5 +42,12 @@ def test_airoh_template_smoke():
         assert output_dir.exists(), "Output directory was not created."
         assert any(output_dir.iterdir()), "Output directory is empty."
 
-        print("✅ Airoh template smoke test succeeded.")
+        # The provenance records are written by fetch and run respectively.
+        assert (tmpdir_path / "source_data" / "MANIFEST.json").is_file()
+        assert (output_dir / "PROVENANCE.json").is_file()
 
+        # A freshly cloned template must pass its own consistency checks: if it
+        # does not, every project generated from it starts out already drifted.
+        subprocess.run(["invoke", "verify"], cwd=tmpdir_path, check=True, env=env)
+
+        print("✅ Airoh template smoke test succeeded.")

--- a/tests/test_datalad.py
+++ b/tests/test_datalad.py
@@ -1,0 +1,290 @@
+import subprocess
+from unittest.mock import patch
+
+import pytest
+from invoke import Context
+from invoke.config import Config
+
+import airoh.datalad as datalad_module
+from airoh.datalad import (
+    _dataset_entry,
+    _require_datalad,
+    datalad_get,
+    ensure_dataset,
+    get_data,
+    install_dataset,
+    install_subdataset,
+    load_known_failures,
+    prefetch_pattern,
+    save_known_failures,
+    update_dataset,
+    update_subdataset,
+)
+
+
+def make_context(datasets_config):
+    config = Config(overrides={"datasets": datasets_config})
+    return Context(config=config)
+
+
+def completed(returncode, stderr=""):
+    return subprocess.CompletedProcess(["datalad"], returncode=returncode, stdout="",
+                                       stderr=stderr)
+
+
+# ---- import / CLI guard ----------------------------------------------------
+
+def test_import_succeeds_without_datalad_cli():
+    # If this module imported at all (it did, at collection time), the guard
+    # is call-time only — this just documents the intent.
+    assert datalad_module is not None
+
+
+def test_require_datalad_raises_with_hint(monkeypatch):
+    monkeypatch.setattr(datalad_module.shutil, "which", lambda name: None)
+    with pytest.raises(RuntimeError, match="pip install airoh\\[datalad\\]"):
+        _require_datalad()
+
+
+def test_require_datalad_passes_when_present(monkeypatch):
+    monkeypatch.setattr(datalad_module.shutil, "which", lambda name: "/usr/bin/datalad")
+    _require_datalad()  # no raise
+
+
+# ---- schema normalization ---------------------------------------------------
+
+def test_dataset_entry_unknown_name_raises():
+    c = make_context({})
+    with pytest.raises(ValueError, match="not found in invoke.yaml"):
+        _dataset_entry(c, "missing")
+
+
+def test_dataset_entry_accepts_plain_string():
+    c = make_context({"cneuromod": "/data/cneuromod"})
+    entry = _dataset_entry(c, "cneuromod")
+    assert entry == {"output_dir": "/data/cneuromod", "url": None, "source": None}
+
+
+def test_dataset_entry_accepts_mapping():
+    c = make_context({
+        "cneuromod": {"output_dir": "/data/cneuromod", "url": "https://example.com/ds",
+                     "source": "/local/checkout"},
+    })
+    entry = _dataset_entry(c, "cneuromod")
+    assert entry == {"output_dir": "/data/cneuromod", "url": "https://example.com/ds",
+                     "source": "/local/checkout"}
+
+
+def test_dataset_entry_mapping_requires_output_dir():
+    c = make_context({"cneuromod": {"url": "https://example.com/ds"}})
+    with pytest.raises(ValueError, match="must define 'output_dir'"):
+        _dataset_entry(c, "cneuromod")
+
+
+# ---- datalad_get -------------------------------------------------------------
+
+@patch("airoh.datalad._require_datalad")
+def test_datalad_get_noop_outside_dataset(mock_require, tmp_path):
+    datalad_get("some/path", tmp_path)  # no .git/.datalad -> tolerant no-op
+    mock_require.assert_called_once()
+
+
+@patch("airoh.datalad._require_datalad")
+def test_datalad_get_strict_outside_dataset_raises(mock_require, tmp_path):
+    with pytest.raises(RuntimeError, match="not a Datalad dataset"):
+        datalad_get("some/path", tmp_path, strict=True)
+
+
+@patch("airoh.datalad._run")
+@patch("airoh.datalad._require_datalad")
+def test_datalad_get_arg_construction(mock_require, mock_run, tmp_path):
+    (tmp_path / ".git").mkdir()
+    mock_run.return_value = completed(0)
+    datalad_get(["a", "b"], tmp_path, recursive=True, get_content=False)
+    args = mock_run.call_args[0][1]
+    assert args == ["get", "-n", "-r", "a", "b"]
+
+
+@patch("airoh.datalad._run")
+@patch("airoh.datalad._require_datalad")
+def test_datalad_get_retries_over_https_on_failure(mock_require, mock_run, tmp_path):
+    (tmp_path / ".git").mkdir()
+    mock_run.side_effect = [completed(1, "auth failed"), completed(0)]
+    datalad_get("a", tmp_path)
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[1][0][0] == datalad_module._HTTPS_OVERRIDE
+
+
+@patch("airoh.datalad._run")
+@patch("airoh.datalad._require_datalad")
+def test_datalad_get_tolerant_warns_on_persistent_failure(mock_require, mock_run,
+                                                           tmp_path, capsys):
+    (tmp_path / ".git").mkdir()
+    mock_run.return_value = completed(1, "still failing")
+    datalad_get("a", tmp_path)
+    assert "returned errors" in capsys.readouterr().out
+
+
+@patch("airoh.datalad._run")
+@patch("airoh.datalad._require_datalad")
+def test_datalad_get_strict_raises_on_persistent_failure(mock_require, mock_run, tmp_path):
+    (tmp_path / ".git").mkdir()
+    mock_run.return_value = completed(1, "still failing")
+    with pytest.raises(RuntimeError, match="datalad get failed"):
+        datalad_get("a", tmp_path, strict=True)
+
+
+def test_run_returns_failure_on_timeout(monkeypatch, tmp_path):
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="datalad", timeout=1)
+    monkeypatch.setattr(datalad_module.subprocess, "run", fake_run)
+    result = datalad_module._run(None, ["get", "x"], tmp_path)
+    assert result.returncode == 1
+    assert "timed out" in result.stderr
+
+
+# ---- install_subdataset / update_subdataset ---------------------------------
+
+@patch("airoh.datalad.datalad_get")
+@patch("airoh.datalad._require_datalad")
+def test_install_subdataset_fresh(mock_require, mock_get, tmp_path):
+    install_subdataset("sub", tmp_path)
+    mock_get.assert_called_once_with("sub", tmp_path, get_content=False, strict=False)
+
+
+@patch("airoh.datalad.update_subdataset")
+@patch("airoh.datalad._require_datalad")
+def test_install_subdataset_already_installed_updates_instead(mock_require, mock_update,
+                                                               tmp_path):
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / ".git").mkdir()
+    install_subdataset("sub", tmp_path)
+    mock_update.assert_called_once_with("sub", tmp_path, strict=False)
+
+
+@patch("airoh.datalad.datalad_get")
+@patch("airoh.datalad._require_datalad")
+def test_install_subdataset_strict_raises_if_still_missing(mock_require, mock_get, tmp_path):
+    with pytest.raises(RuntimeError, match="was not installed"):
+        install_subdataset("sub", tmp_path, strict=True)
+
+
+@patch("airoh.datalad._require_datalad")
+def test_update_subdataset_noop_when_not_installed(mock_require, tmp_path):
+    update_subdataset("sub", tmp_path)  # no .git -> no-op, no error
+
+
+# ---- ensure_dataset ----------------------------------------------------------
+
+def test_ensure_dataset_noop_when_dest_exists(tmp_path, capsys):
+    dest = tmp_path / "existing"
+    dest.mkdir()
+    ensure_dataset(dest)
+    assert "already exists" in capsys.readouterr().out
+
+
+def test_ensure_dataset_symlinks_from_source(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    dest = tmp_path / "dest"
+    ensure_dataset(dest, source=source)
+    assert dest.is_symlink()
+    assert dest.resolve() == source.resolve()
+
+
+def test_ensure_dataset_missing_source_raises(tmp_path):
+    dest = tmp_path / "dest"
+    with pytest.raises(ValueError, match="does not exist"):
+        ensure_dataset(dest, source=tmp_path / "nowhere")
+
+
+@patch("airoh.datalad.subprocess.run")
+@patch("airoh.datalad._require_datalad")
+def test_ensure_dataset_clones_from_url(mock_require, mock_run, tmp_path):
+    dest = tmp_path / "dest"
+    ensure_dataset(dest, url="https://example.com/ds.git")
+    mock_run.assert_called_once()
+    assert mock_run.call_args[0][0] == ["datalad", "clone", "https://example.com/ds.git",
+                                        str(dest)]
+
+
+def test_ensure_dataset_no_source_or_url_raises(tmp_path):
+    dest = tmp_path / "dest"
+    with pytest.raises(ValueError, match="neither 'source' nor 'url'"):
+        ensure_dataset(dest)
+
+
+# ---- failure cache -----------------------------------------------------------
+
+def test_failure_cache_round_trip(tmp_path):
+    assert load_known_failures(tmp_path) == set()
+    save_known_failures(tmp_path, {"a/b.nii.gz", "c/d.json"})
+    assert load_known_failures(tmp_path) == {"a/b.nii.gz", "c/d.json"}
+
+
+# ---- prefetch_pattern --------------------------------------------------------
+
+@patch("airoh.datalad.datalad_get")
+def test_prefetch_pattern_counts_already_present_files(mock_get, tmp_path):
+    sub = tmp_path / "marker"
+    sub.mkdir()
+    (sub / "present.json").write_text("{}")
+    present, fetched, skipped, new_failures, resolved = prefetch_pattern(
+        tmp_path, "*.json", subdir="marker")
+    assert (present, fetched, skipped, new_failures, resolved) == (1, 0, 0, set(), set())
+    mock_get.assert_not_called()
+
+
+def test_prefetch_pattern_missing_dir_returns_zeros(tmp_path):
+    result = prefetch_pattern(tmp_path, "*.json", subdir="absent")
+    assert result == (0, 0, 0, set(), set())
+
+
+@patch("airoh.datalad.datalad_get")
+def test_prefetch_pattern_fetches_missing_and_skips_known_failures(mock_get, tmp_path):
+    marker = tmp_path / "marker"
+    marker.mkdir()
+    # Create broken symlinks so rglob finds them as "missing" (matched but not is_file()).
+    missing_target = marker / "missing.json"
+    skipped_target = marker / "skipped.json"
+    missing_target.symlink_to(tmp_path / "nonexistent-1")
+    skipped_target.symlink_to(tmp_path / "nonexistent-2")
+
+    def fake_get(paths, root):
+        # datalad_get is asked only for the non-skipped missing file.
+        assert [str(p) for p in paths] == ["marker/missing.json"]
+        missing_target.unlink()
+        missing_target.write_text("{}")
+    mock_get.side_effect = fake_get
+
+    present, fetched, skipped, new_failures, resolved = prefetch_pattern(
+        tmp_path, "*.json", subdir="marker", skip_set={"marker/skipped.json"})
+    assert present == 0
+    assert fetched == 1
+    assert skipped == 1
+    assert new_failures == set()
+    assert resolved == {"marker/missing.json"}
+
+
+# ---- invoke tasks (thin wrappers) -------------------------------------------
+
+@patch("airoh.datalad.ensure_dataset")
+def test_install_dataset_task_routes_to_ensure_dataset(mock_ensure):
+    c = make_context({"cneuromod": {"output_dir": "/d", "url": "https://x/ds",
+                                    "source": None}})
+    install_dataset(c, "cneuromod")
+    mock_ensure.assert_called_once_with("/d", url="https://x/ds", source=None)
+
+
+@patch("airoh.datalad.datalad_get")
+def test_get_data_task_routes_to_datalad_get(mock_get):
+    c = make_context({"cneuromod": {"output_dir": "/d"}})
+    get_data(c, "cneuromod", path="sub-01", strict=True)
+    mock_get.assert_called_once_with("sub-01", "/d", recursive=False, strict=True)
+
+
+@patch("airoh.datalad.update_subdataset")
+def test_update_dataset_task_routes_to_update_subdataset(mock_update):
+    c = make_context({"cneuromod": {"output_dir": "/data/cneuromod"}})
+    update_dataset(c, "cneuromod")
+    mock_update.assert_called_once_with("cneuromod", "/data", strict=False)

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,258 @@
+"""Unit tests for airoh.provenance — the records, and their tolerance of missing data."""
+
+import json
+import subprocess
+
+import pytest
+from invoke import Context
+from invoke.config import Config
+
+from airoh.provenance import (
+    _parse_pyproject_dependencies,
+    describe_path,
+    git_info,
+    parse_requirements,
+    record_run,
+    record_sources,
+    requirement_name,
+    sha256_file,
+)
+
+EMPTY_SHA = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+
+@pytest.fixture
+def context(tmp_path, monkeypatch):
+    """An invoke Context rooted in an empty project directory."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "source_data").mkdir()
+    (tmp_path / "output_data").mkdir()
+    return Context(config=Config(overrides={
+        "source_data_dir": "source_data",
+        "output_data_dir": "output_data",
+    }))
+
+
+def git_repo(root):
+    """Initialize and commit everything in ``root``; skip if git is absent."""
+    try:
+        for args in (["init", "-q"], ["add", "-A"],
+                     ["-c", "user.email=t@t", "-c", "user.name=t",
+                      "commit", "-qm", "init"]):
+            subprocess.run(["git"] + args, cwd=str(root), check=True,
+                           capture_output=True)
+    except (OSError, subprocess.CalledProcessError) as error:
+        pytest.skip(f"git unavailable: {error}")
+
+
+# --------------------------------------------------------------------------- #
+# Primitives
+# --------------------------------------------------------------------------- #
+def test_sha256_file_hashes_content(tmp_path):
+    path = tmp_path / "a.txt"
+    path.write_text("")
+    assert sha256_file(path) == EMPTY_SHA
+
+
+def test_sha256_file_skips_oversized(tmp_path):
+    path = tmp_path / "a.txt"
+    path.write_text("x" * 100)
+    assert sha256_file(path, max_bytes=10) is None
+
+
+def test_sha256_file_tolerates_missing(tmp_path):
+    assert sha256_file(tmp_path / "nope.txt") is None
+
+
+def test_requirement_name_strips_specifiers():
+    assert requirement_name("numpy>=1.3") == "numpy"
+    assert requirement_name("git-annex >= 10.2") == "git-annex"
+    assert requirement_name('pandas[extra]==2.0; python_version<"3.12"') == "pandas"
+
+
+def test_parse_requirements_ignores_comments_and_flags(tmp_path):
+    path = tmp_path / "requirements.txt"
+    path.write_text("# a comment\nnumpy>=1.0\n\n-r other.txt\npandas  # trailing\n")
+    assert parse_requirements(path) == ["numpy", "pandas"]
+
+
+def test_parse_pyproject_dependencies(tmp_path):
+    path = tmp_path / "pyproject.toml"
+    path.write_text('[project]\nname = "x"\ndependencies = [\n  "numpy",\n  "pandas>=2",\n]\n')
+    assert _parse_pyproject_dependencies(path) == ["numpy", "pandas"]
+
+
+# --------------------------------------------------------------------------- #
+# describe_path
+# --------------------------------------------------------------------------- #
+def test_describe_path_records_absence(tmp_path):
+    record = describe_path(tmp_path / "nope")
+    assert record["exists"] is False
+    assert record["sha256"] is None
+
+
+def test_describe_path_records_a_file(tmp_path):
+    path = tmp_path / "data.tsv"
+    path.write_text("")
+    record = describe_path(path)
+    assert record["exists"] is True
+    assert record["size_bytes"] == 0
+    assert record["sha256"] == EMPTY_SHA
+
+
+def test_describe_path_resolves_a_symlink(tmp_path):
+    """A symlinked asset must be attributed to what it really points at."""
+    real = tmp_path / "elsewhere"
+    real.mkdir()
+    (real / "x.txt").write_text("hello")
+    link = tmp_path / "linked"
+    link.symlink_to(real, target_is_directory=True)
+
+    record = describe_path(link)
+    assert record["is_symlink"] is True
+    assert record["resolved_path"] == str(real)
+
+
+def test_describe_path_records_git_commit(tmp_path):
+    (tmp_path / "x.txt").write_text("hello")
+    git_repo(tmp_path)
+    record = describe_path(tmp_path / "x.txt")
+    assert record["git"]["commit"]
+    assert record["git"]["dirty"] is False
+
+
+def test_describe_path_records_datalad_id(tmp_path):
+    (tmp_path / ".datalad").mkdir()
+    (tmp_path / ".datalad" / "config").write_text("[datalad \"dataset\"]\n\tid = abc-123\n")
+    assert describe_path(tmp_path)["datalad_id"] == "abc-123"
+
+
+def test_git_info_returns_none_outside_a_repository(tmp_path):
+    assert git_info(tmp_path) is None
+
+
+# --------------------------------------------------------------------------- #
+# record_sources
+# --------------------------------------------------------------------------- #
+def test_record_sources_describes_each_asset(context, tmp_path):
+    (tmp_path / "source_data" / "papers.tsv").write_text("a\tb\n")
+    context.config["files"] = {
+        "papers": {"url": "https://example.com/p.tsv",
+                   "output_file": "source_data/papers.tsv"}}
+
+    record_sources(context)
+    manifest = json.loads((tmp_path / "source_data" / "MANIFEST.json").read_text())
+    papers = manifest["assets"]["papers"]
+    assert papers["exists"] is True
+    assert papers["mode"] == "download"
+    assert papers["sha256"]
+
+
+def test_record_sources_records_an_unfetched_asset_as_absent(context, tmp_path):
+    context.config["files"] = {
+        "papers": {"url": "https://example.com/p.tsv",
+                   "output_file": "source_data/papers.tsv"}}
+
+    record_sources(context)
+    manifest = json.loads((tmp_path / "source_data" / "MANIFEST.json").read_text())
+    assert manifest["assets"]["papers"]["exists"] is False
+
+
+def test_record_sources_handles_datasets_as_plain_paths(context, tmp_path):
+    """airoh.datalad.get_data declares a dataset as a bare path string."""
+    (tmp_path / "source_data" / "ds").mkdir()
+    context.config["datasets"] = {"ds": "source_data/ds"}
+
+    record_sources(context)
+    manifest = json.loads((tmp_path / "source_data" / "MANIFEST.json").read_text())
+    assert manifest["assets"]["ds"]["exists"] is True
+
+
+def test_record_sources_drops_self_attribution(context, tmp_path):
+    """An asset inside the project repo must not borrow the project's commit."""
+    (tmp_path / "source_data" / "papers.tsv").write_text("a\n")
+    git_repo(tmp_path)
+    context.config["files"] = {"papers": {"output_file": "source_data/papers.tsv"}}
+
+    record_sources(context)
+    manifest = json.loads((tmp_path / "source_data" / "MANIFEST.json").read_text())
+    assert manifest["assets"]["papers"]["git"] is None
+
+
+def test_record_sources_keeps_external_repository_commit(context, tmp_path):
+    """The point of the manifest: pin a symlinked external checkout."""
+    external = tmp_path.parent / (tmp_path.name + "_external")
+    external.mkdir()
+    (external / "data.txt").write_text("hello")
+    git_repo(external)
+    (tmp_path / "source_data" / "linked").symlink_to(external, target_is_directory=True)
+    git_repo(tmp_path)
+    context.config["datasets"] = {"ext": {"output_dir": "source_data/linked"}}
+
+    record_sources(context)
+    manifest = json.loads((tmp_path / "source_data" / "MANIFEST.json").read_text())
+    asset = manifest["assets"]["ext"]
+    assert asset["mode"] == "symlink"
+    assert asset["git"]["commit"]
+
+
+# --------------------------------------------------------------------------- #
+# record_run
+# --------------------------------------------------------------------------- #
+def test_record_run_checksums_outputs(context, tmp_path):
+    (tmp_path / "output_data" / "result.csv").write_text("a,b\n")
+
+    record_run(context, tasks="run-model")
+    record = json.loads((tmp_path / "output_data" / "PROVENANCE.json").read_text())
+    assert record["tasks"] == ["run-model"]
+    assert record["outputs"]["result.csv"]["sha256"]
+    assert record["environment"]["python"]
+
+
+def test_record_run_excludes_itself_from_the_outputs(context, tmp_path):
+    (tmp_path / "output_data" / "result.csv").write_text("a,b\n")
+
+    record_run(context)
+    record_run(context)  # the first record must not become an input to the second
+    record = json.loads((tmp_path / "output_data" / "PROVENANCE.json").read_text())
+    assert list(record["outputs"]) == ["result.csv"]
+
+
+def test_record_run_links_to_the_manifest(context, tmp_path):
+    (tmp_path / "source_data" / "papers.tsv").write_text("a\n")
+    context.config["files"] = {"papers": {"output_file": "source_data/papers.tsv"}}
+    record_sources(context)
+
+    record_run(context)
+    record = json.loads((tmp_path / "output_data" / "PROVENANCE.json").read_text())
+    assert record["inputs"]["manifest_sha256"]
+    assert record["inputs"]["assets"]["papers"]["sha256"]
+
+
+def test_record_run_tolerates_a_missing_manifest(context, tmp_path):
+    """Provenance is documentation; it can never be a precondition."""
+    record_run(context)
+    record = json.loads((tmp_path / "output_data" / "PROVENANCE.json").read_text())
+    assert record["inputs"]["manifest_sha256"] is None
+
+
+def test_record_run_records_the_project_commit(context, tmp_path):
+    (tmp_path / "output_data" / "result.csv").write_text("a,b\n")
+    git_repo(tmp_path)
+
+    record_run(context)
+    record = json.loads((tmp_path / "output_data" / "PROVENANCE.json").read_text())
+    assert record["repository"]["commit"]
+    # State is captured before the record is written, so a committed tree is clean.
+    assert record["repository"]["dirty"] is False
+
+
+def test_record_run_flags_an_uncommitted_tree(context, tmp_path):
+    """Outputs produced from edited-but-uncommitted code must say so."""
+    (tmp_path / "output_data" / "result.csv").write_text("a,b\n")
+    git_repo(tmp_path)
+    (tmp_path / "output_data" / "result.csv").write_text("a,b,c\n")
+
+    record_run(context)
+    record = json.loads((tmp_path / "output_data" / "PROVENANCE.json").read_text())
+    assert record["repository"]["dirty"] is True

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,0 +1,352 @@
+"""Unit tests for airoh.verify — each check in its passing and failing shape."""
+
+import subprocess
+
+import pytest
+
+from airoh.verify import (
+    FAIL,
+    PASS,
+    SKIP,
+    WARN,
+    Project,
+    check_config_keys,
+    check_content_md,
+    check_dependencies,
+    check_doc_paths,
+    check_provenance,
+    check_task_list,
+    check_tracked_size,
+    config_keys_used,
+    documented_task_names,
+    run_checks,
+    task_names,
+)
+
+CONFIG = {"source_data_dir": "source_data", "output_data_dir": "output_data"}
+
+TASKS_PY = '''
+from invoke import task
+
+@task
+def fetch(c):
+    """Fetch."""
+    print(c.config.get("source_data_dir"))
+
+@task(pre=[fetch])
+def run_model(c):
+    """Run."""
+    print(c.config.get("output_data_dir"))
+'''
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A minimal, internally consistent airoh project."""
+    (tmp_path / "tasks.py").write_text(TASKS_PY)
+    (tmp_path / "invoke.yaml").write_text(
+        "source_data_dir: source_data\noutput_data_dir: output_data\n")
+    (tmp_path / "README.md").write_text(
+        "Run `invoke fetch` then `invoke run-model`.\n")
+    (tmp_path / "CLAUDE.md").write_text("See `tasks.py`.\n")
+    for name in ("source_data", "output_data"):
+        (tmp_path / name).mkdir()
+        (tmp_path / name / "CONTENT.md").write_text(f"# {name}\n")
+    return tmp_path
+
+
+def make(root, config=None):
+    return Project(config or CONFIG, root)
+
+
+# --------------------------------------------------------------------------- #
+# Parsing helpers
+# --------------------------------------------------------------------------- #
+def test_task_names_reads_decorated_functions(project):
+    assert task_names(project / "tasks.py") == ["fetch", "run-model"]
+
+
+def test_task_names_returns_none_on_unparseable_file(tmp_path):
+    (tmp_path / "tasks.py").write_text("def broken(:\n")
+    assert task_names(tmp_path / "tasks.py") is None
+
+
+def test_documented_task_names_ignores_prose_and_placeholders():
+    text = ("This repo has reusable invoke tasks.\n"
+            "Run `invoke fetch` and `invoke run-model`.\n"
+            "Each asset gets an `invoke fetch-{name}` task.\n")
+    assert documented_task_names(text) == {"fetch", "run-model"}
+
+
+def test_config_keys_used_ignores_chained_lookups(tmp_path):
+    (tmp_path / "tasks.py").write_text(
+        'x = c.config.get("datasets", {}).get("inner", {})\n'
+        'y = c.config.get("output_data_dir")\n')
+    assert config_keys_used(tmp_path / "tasks.py") == {"datasets", "output_data_dir"}
+
+
+# --------------------------------------------------------------------------- #
+# Checks
+# --------------------------------------------------------------------------- #
+def test_task_list_passes_when_docs_match(project):
+    assert check_task_list(make(project)).status == PASS
+
+
+def test_task_list_fails_on_undocumented_task(project):
+    (project / "README.md").write_text("Run `invoke fetch`.\n")
+    finding = check_task_list(make(project))
+    assert finding.status == FAIL
+    assert any("run-model" in detail for detail in finding.details)
+
+
+def test_task_list_fails_on_documented_phantom(project):
+    """The drift that motivated this check: a task the docs invent."""
+    (project / "README.md").write_text(
+        "Run `invoke fetch`, `invoke run-model`, `invoke run-smoke`.\n")
+    finding = check_task_list(make(project))
+    assert finding.status == FAIL
+    assert any("run-smoke" in detail for detail in finding.details)
+
+
+def test_task_list_accepts_a_table_row(project):
+    """A README table names a task without spelling out `invoke`."""
+    (project / "README.md").write_text(
+        "Run `invoke fetch`.\n\n| Task | Description |\n"
+        "| --- | --- |\n| `run-model` | Fits the model |\n")
+    assert check_task_list(make(project)).status == PASS
+
+
+def test_task_list_still_flags_a_phantom_invocation(project):
+    """Mentioning a name is documentation; `invoke <name>` is a claim it exists."""
+    (project / "README.md").write_text(
+        "Run `invoke fetch`, `invoke run-model`.\n"
+        "The `conda-forge` channel is fine, but `invoke run-nothing` is not.\n")
+    finding = check_task_list(make(project))
+    assert finding.status == FAIL
+    assert finding.details == ["documented but not defined: run-nothing"]
+
+
+def test_dependencies_pass_when_files_agree(project):
+    (project / "pyproject.toml").write_text(
+        '[project]\ndependencies = ["numpy>=1.0", "pandas"]\n')
+    (project / "requirements.txt").write_text("numpy>=1.0\npandas\n")
+    assert check_dependencies(make(project)).status == PASS
+
+
+def test_dependencies_fail_when_requirements_lags(project):
+    (project / "pyproject.toml").write_text(
+        '[project]\ndependencies = ["numpy", "pandas", "nilearn"]\n')
+    (project / "requirements.txt").write_text("numpy\n")
+    finding = check_dependencies(make(project))
+    assert finding.status == FAIL
+    assert any("nilearn" in detail for detail in finding.details)
+
+
+def test_dependencies_skip_conda_channels(project):
+    (project / "requirements.txt").write_text("numpy\n")
+    (project / "environment.yml").write_text(
+        "channels:\n  - conda-forge\ndependencies:\n  - python=3.12\n  - numpy\n")
+    assert check_dependencies(make(project)).status == PASS
+
+
+def test_dependencies_skip_with_one_file(project):
+    (project / "requirements.txt").write_text("numpy\n")
+    assert check_dependencies(make(project)).status == SKIP
+
+
+def test_doc_paths_pass_for_existing_paths(project):
+    (project / "CLAUDE.md").write_text("See `tasks.py` and `invoke.yaml`.\n")
+    assert check_doc_paths(make(project)).status == PASS
+
+
+def test_doc_paths_fail_for_missing_source_file(project):
+    (project / "CLAUDE.md").write_text("Delete `analysis/simulation.py`.\n")
+    finding = check_doc_paths(make(project))
+    assert finding.status == FAIL
+    assert any("simulation.py" in detail for detail in finding.details)
+
+
+def test_doc_paths_warn_for_unproduced_output(project):
+    (project / "output_data" / "CONTENT.md").write_text("- `scatter.png` — a plot.\n")
+    finding = check_doc_paths(make(project))
+    assert finding.status == WARN
+    assert any("scatter.png" in detail for detail in finding.details)
+
+
+def test_doc_paths_ignore_placeholders_and_conventions(project):
+    (project / "CLAUDE.md").write_text(
+        "Writes `output_data/tables/{dataset}.tsv` from `*_bold.json` files.\n")
+    assert check_doc_paths(make(project)).status == PASS
+
+
+def test_doc_paths_resolve_bare_basenames(project):
+    """Docs name a file without saying where it lives."""
+    (project / "analysis").mkdir()
+    (project / "analysis" / "model.py").write_text("")
+    (project / "CLAUDE.md").write_text("The heavy lifting is in `model.py`.\n")
+    assert check_doc_paths(make(project)).status == PASS
+
+
+def test_doc_paths_warn_for_a_missing_bare_filename(project):
+    """A bare name claims a file exists somewhere, not that it exists here."""
+    (project / "CLAUDE.md").write_text("`run` writes `PROVENANCE.json`.\n")
+    finding = check_doc_paths(make(project))
+    assert finding.status == WARN
+    assert any("PROVENANCE.json" in detail for detail in finding.details)
+
+
+def test_doc_paths_keep_leading_dot_directories(project):
+    """`.claude/skills` must not be mangled into `claude/skills`."""
+    (project / ".claude" / "skills").mkdir(parents=True)
+    (project / "CLAUDE.md").write_text("Skills live in `.claude/skills/`.\n")
+    assert check_doc_paths(make(project)).status == PASS
+
+
+def test_doc_paths_strip_a_leading_dot_slash(project):
+    (project / "CLAUDE.md").write_text("See `./tasks.py`.\n")
+    assert check_doc_paths(make(project)).status == PASS
+
+
+def test_doc_paths_honour_ignore_list(project):
+    (project / "CLAUDE.md").write_text("See `analysis/simulation.py`.\n")
+    config = dict(CONFIG, verify={"ignore_paths": ["analysis/*"]})
+    assert check_doc_paths(make(project, config)).status == PASS
+
+
+def test_content_md_passes_when_entries_are_described(project):
+    (project / "output_data" / "result.csv").write_text("a,b\n")
+    (project / "output_data" / "CONTENT.md").write_text("- `result.csv` — output.\n")
+    assert check_content_md(make(project)).status == PASS
+
+
+def test_content_md_fails_on_undocumented_entry(project):
+    (project / "output_data" / "surprise.csv").write_text("a,b\n")
+    finding = check_content_md(make(project))
+    assert finding.status == FAIL
+    assert any("surprise.csv" in detail for detail in finding.details)
+
+
+def test_content_md_ignores_provenance_records(project):
+    (project / "output_data" / "PROVENANCE.json").write_text("{}")
+    (project / "source_data" / "MANIFEST.json").write_text("{}")
+    assert check_content_md(make(project)).status == PASS
+
+
+def test_config_keys_pass_when_declared(project):
+    assert check_config_keys(make(project)).status == PASS
+
+
+def test_config_keys_fail_on_undeclared_key(project):
+    (project / "invoke.yaml").write_text("source_data_dir: source_data\n")
+    finding = check_config_keys(make(project))
+    assert finding.status == FAIL
+    assert any("output_data_dir" in detail for detail in finding.details)
+
+
+def test_config_keys_warn_on_unused_key(project):
+    (project / "invoke.yaml").write_text(
+        "source_data_dir: source_data\noutput_data_dir: output_data\ncode_dir: analysis\n")
+    finding = check_config_keys(make(project))
+    assert finding.status == WARN
+    assert any("code_dir" in detail for detail in finding.details)
+
+
+def test_provenance_warns_when_record_missing(project):
+    (project / "output_data" / "result.csv").write_text("a,b\n")
+    finding = check_provenance(make(project))
+    assert finding.status == WARN
+    assert any("PROVENANCE.json" in detail for detail in finding.details)
+
+
+def test_provenance_skips_on_empty_project(project):
+    assert check_provenance(make(project)).status == SKIP
+
+
+def test_provenance_ignores_bookkeeping_when_dating_outputs(project):
+    """Editing CONTENT.md must not make the record look stale."""
+    (project / "output_data" / "result.csv").write_text("a,b\n")
+    (project / "output_data" / "CONTENT.md").write_text("- `result.csv`\n")
+    (project / "source_data" / "MANIFEST.json").write_text("{}")
+    record = project / "output_data" / "PROVENANCE.json"
+    record.write_text("{}")
+    (project / "output_data" / "CONTENT.md").touch()  # edited after the run
+
+    assert check_provenance(make(project)).status == PASS
+
+
+# --------------------------------------------------------------------------- #
+# git-backed check
+# --------------------------------------------------------------------------- #
+def git_repo(root):
+    """Initialize and commit everything in ``root``; skip if git is absent."""
+    try:
+        for args in (["init", "-q"], ["add", "-A"],
+                     ["-c", "user.email=t@t", "-c", "user.name=t",
+                      "commit", "-qm", "init"]):
+            subprocess.run(["git"] + args, cwd=str(root), check=True,
+                           capture_output=True)
+    except (OSError, subprocess.CalledProcessError) as error:
+        pytest.skip(f"git unavailable: {error}")
+
+
+def test_tracked_size_skips_outside_a_repo(project):
+    assert check_tracked_size(make(project)).status == SKIP
+
+
+def test_tracked_size_passes_on_small_repo(project):
+    git_repo(project)
+    assert check_tracked_size(make(project)).status == PASS
+
+
+def test_tracked_size_fails_on_oversized_file(project):
+    (project / "big.txt").write_text("x" * 4096)
+    git_repo(project)
+    config = dict(CONFIG, verify={"max_tracked_bytes": 1024})
+    finding = check_tracked_size(make(project, config))
+    assert finding.status == FAIL
+    assert any("big.txt" in detail for detail in finding.details)
+
+
+def test_tracked_size_fails_on_risky_extension(project):
+    (project / "source_data" / "brain.nii.gz").write_text("x")
+    (project / "source_data" / "CONTENT.md").write_text("- `brain.nii.gz`\n")
+    git_repo(project)
+    finding = check_tracked_size(make(project))
+    assert finding.status == FAIL
+    assert any("brain.nii.gz" in detail for detail in finding.details)
+
+
+def test_tracked_size_allows_archives_under_dot_directories(project):
+    skill = project / ".claude" / "skills"
+    skill.mkdir(parents=True)
+    (skill / "init.zip").write_text("x")
+    git_repo(project)
+    assert check_tracked_size(make(project)).status == PASS
+
+
+# --------------------------------------------------------------------------- #
+# Runner
+# --------------------------------------------------------------------------- #
+def test_run_checks_reports_every_check(project):
+    findings = run_checks(CONFIG, root=project)
+    assert {f.check for f in findings} == {
+        "content_md", "task_list", "dependencies", "doc_paths", "config_keys",
+        "tracked_size", "provenance", "lint"}
+
+
+def test_run_checks_honours_skip(project):
+    findings = {f.check: f for f in run_checks(CONFIG, root=project, skip=["lint"])}
+    assert findings["lint"].status == SKIP
+    assert "configuration" in findings["lint"].message
+
+
+def test_run_checks_survives_a_broken_check(project, monkeypatch):
+    """One exploding check must not hide the others."""
+    def explode(_):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("airoh.verify.CHECKS", (explode, check_task_list))
+    explode.__name__ = "check_explode"
+    findings = run_checks(CONFIG, root=project)
+    assert findings[0].status == SKIP and "boom" in findings[0].message
+    assert findings[1].status == PASS

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -154,6 +154,17 @@ def test_dependencies_skip_with_one_file(project):
     assert check_dependencies(make(project)).status == SKIP
 
 
+def test_dependencies_ignore_pip_flags_in_conda_env(project):
+    (project / "pyproject.toml").write_text(
+        '[project]\ndependencies = ["numpy"]\n')
+    (project / "environment.yml").write_text(
+        "dependencies:\n  - python=3.12\n  - numpy\n  - pip\n  - pip:\n"
+        "    - -e .\n    - -r requirements.txt\n")
+    finding = check_dependencies(make(project))
+    assert finding.status == PASS
+    assert not any(detail.startswith("-") for detail in finding.details)
+
+
 def test_doc_paths_pass_for_existing_paths(project):
     (project / "CLAUDE.md").write_text("See `tasks.py` and `invoke.yaml`.\n")
     assert check_doc_paths(make(project)).status == PASS


### PR DESCRIPTION
## Summary
- **`airoh/verify.py`** (new): `invoke verify` — a flat list of independent checks that code, config, data and docs still agree (task list vs. docs, dependency files, doc paths, `CONTENT.md` coverage, config keys, tracked file sizes, provenance freshness, lint).
- **`airoh/provenance.py`** (new): `record_sources` writes `source_data/MANIFEST.json`, `record_run` writes `output_data/PROVENANCE.json` — checksummed, git/datalad-aware.
- **`airoh/datalad.py`** (rewritten): tolerant-by-default retrieval (`--strict` to raise), HTTPS retry for SSH-only environments, non-interactive git/ssh env with bounded timeouts so unreachable remotes fail fast instead of hanging, `ensure_dataset`/`install_dataset` (symlink or clone), nested subdataset install/update, a failure cache, and a `prefetch_pattern` glob-and-fetch helper. CLI guard moved from import time to call time; broken `import_archive` removed.
- Version bumped to 0.4.0.

## Test plan
- [x] 112 unit tests pass (`pytest -m "not integration"`)
- [x] `ruff check airoh/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPS97cU9UNhoF8Tq5eHqeu